### PR TITLE
Release 2.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-   s.version                 = "2.0.3"
+   s.version                 = "2.0.4"
    s.name                    = "AirshipFrameworkProxy"
    s.summary                 = "Airship iOS mobile framework proxy"
    s.documentation_url       = "https://docs.airship.com/platform/mobile"

--- a/android/airship-framework-proxy/build.gradle
+++ b/android/airship-framework-proxy/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group = 'com.urbanairship.android'
 description = "Airship Mobile Framework Proxy"
-version = rootProject.adapterVersion
+version = libs.versions.airshipProxy.get()
 
 android {
     namespace 'com.urbanairship.android.framework.proxy'
@@ -25,7 +25,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-     kotlinOptions {
+    kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
         freeCompilerArgs = ["-Xexplicit-api=strict"]
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     ext {
-        adapterVersion = '2.0.3'
         // Android SDK versions
         compileSdkVersion = 33
         targetSdkVersion = 33
@@ -19,7 +18,7 @@ plugins {
 
 task getVersion() {
     doLast {
-        println adapterVersion
+        println libs.versions.airshipProxy.get()
     }
 }
 
@@ -39,10 +38,10 @@ nexusPublishing {
         }
         transitionCheckOptions {
             maxRetries.set(100)
-            delayBetween.set(Duration.ofSeconds(60*2))
+            delayBetween.set(Duration.ofSeconds(60 * 2))
         }
-        connectTimeout = Duration.ofSeconds(60*30)
-        clientTimeout = Duration.ofSeconds(60*30)
+        connectTimeout = Duration.ofSeconds(60 * 30)
+        clientTimeout = Duration.ofSeconds(60 * 30)
     } else {
         logger.info("Missing publishing credentials! Nexus publishing will not be configured.")
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,9 @@
 [versions]
 
+# Airship
+airshipProxy = '2.0.3'
+airship = '16.9.1'
+
 # Gradle plugins
 androidGradlePlugin = '7.3.0'
 nexusPublishPlugin = '1.1.0'
@@ -17,9 +21,6 @@ kotlinx-coroutines = '1.6.4'
 
 # Androidx
 androidx-annotation = '1.4.0'
-
-# Firebase
-airship = '16.9.1'
 
 # Test
 google-truth = '1.1.3'

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
 # Airship
-airshipProxy = '2.0.3'
-airship = '16.9.1'
+airshipProxy = '2.0.4'
+airship = '16.9.2'
 
 # Gradle plugins
 androidGradlePlugin = '7.3.0'


### PR DESCRIPTION
* Update deprecated set-output in `release.yml` workflow
* Moved some versions around so that bumping android can be done by editing the `airship` and `airshipProxy` versions in `libs.versions.toml`
* Bumped to Android SDK 16.9.2
* Bumped Android Proxy version to 2.0.4
* Also bumped iOS to 2.0.4, to match, but didn't make any changes on the iOS side.

The Android release is still in progress, so this probably won't pass CI for a little bit.