### PR TITLE
Add missing completionHandler call in receivedDeepLink ios function

### DIFF
--- a/ios/AirshipFrameworkProxy/AirshipDelegate.swift
+++ b/ios/AirshipFrameworkProxy/AirshipDelegate.swift
@@ -94,6 +94,7 @@ class AirshipDelegate: NSObject,
             await self.eventEmitter.addEvent(
                 DeepLinkEvent(deepLink)
             )
+            completionHandler()
         }
     }
     


### PR DESCRIPTION
After migration of react native library from 14.4.2 to 15.2.1 (and later 15.2.3), we've seen that js stopped getting `NotificationResponseEvent` after tapping on push notification with deeplink and payload. 
Example push notification payload:
```json
{
    "audience": {
        "device_token": "token"
    },
    "notification": {
      "alert": "Hello!",
      "actions": {
        "open": {
            "type": "deep_link",
            "content": "some_deeplink"
          }
      },
      "ios": {
        "extra": {
          "type": "test",
          "title": "Hello",
          "description": "World",
        },
        "content_available": true
      }
  },
  "device_types": [
      "ios"
  ]
}
``` 

After some debugging and comparing old version with new one, we've seen missing `completionHandler` call in `receivedDeepLink` function (`ios/AirshipFrameworkProxy/AirshipDelegate.swift`), which results in not leaving `dispatchGroup` and not calling this fragment of code:

![image](https://user-images.githubusercontent.com/44415389/234525856-3ea52d6f-09a1-435a-bcc4-9abda125a9f6.png)

in `didReceiveNotificationResponse` function (https://github.com/urbanairship/ios-library/blob/61c8b72eafe6b939aa6a07a04bdcd28a315f06a4/Airship/AirshipCore/Source/DefaultAppIntegrationDelegate.swift#L121).

As you can see on following screenshot, there was a call of `completionHandler` in old version:

![image](https://user-images.githubusercontent.com/44415389/234527204-5166201c-df68-4f01-acdf-3abd19e826d0.png)

