### PR TITLE
Update MessageCenterUpdatedEvent body for iOS

### DIFF
--- a/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
+++ b/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
@@ -44,7 +44,7 @@ struct MessageCenterUpdatedEvent: AirshipProxyEvent {
     init(messageCount: UInt, unreadCount: Int) {
         self.body = [
             "messageCount": messageCount,
-            "unreadCount": unreadCount
+            "messageUnreadCount": unreadCount
         ]
     }
 }


### PR DESCRIPTION
Fix MessageCenterUpdatedEvent body for iOS to be the same as Android