### PR TITLE
[MOBILE-4010] Fix android locale override

### DIFF
--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-   s.version                 = "5.0.1"
+   s.version                 = "5.0.2"
    s.name                    = "AirshipFrameworkProxy"
    s.summary                 = "Airship iOS mobile framework proxy"
    s.documentation_url       = "https://docs.airship.com/platform/mobile"

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
@@ -1,12 +1,13 @@
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.locale.LocaleManager
-import java.util.*
+import java.util.Locale
 
 public class LocaleProxy internal constructor(private val localeProvider: () -> LocaleManager) {
 
     public fun setCurrentLocale(localeIdentifier: String) {
-        localeProvider().setLocaleOverride(Locale(localeIdentifier))
+        val localeParams = localeIdentifier.split("-", "_")
+        localeProvider().setLocaleOverride(Locale(localeParams[0], if (localeParams.size > 1) localeParams[1] else ""))
     }
 
     public fun getCurrentLocale(): String {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
@@ -6,8 +6,7 @@ import java.util.Locale
 public class LocaleProxy internal constructor(private val localeProvider: () -> LocaleManager) {
 
     public fun setCurrentLocale(localeIdentifier: String) {
-        val localeParams = localeIdentifier.split("-", "_")
-        localeProvider().setLocaleOverride(Locale(localeParams[0], if (localeParams.size > 1) localeParams[1] else ""))
+        localeProvider().setLocaleOverride(Locale.forLanguageTag(localeIdentifier))
     }
 
     public fun getCurrentLocale(): String {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Airship
-airshipProxy = '5.0.1'
+airshipProxy = '5.0.2'
 airship = '17.5.0'
 
 # Gradle plugins

--- a/ios/AirshipFrameworkProxy/AirshipProxyEventEmitter.swift
+++ b/ios/AirshipFrameworkProxy/AirshipProxyEventEmitter.swift
@@ -5,7 +5,11 @@ public actor AirshipProxyEventEmitter {
     private let updateContinuation: AsyncStream<AirshipProxyEvent>.Continuation
     public let pendingEventAdded: AsyncStream<AirshipProxyEvent>
     public static let shared = AirshipProxyEventEmitter()
-    public nonisolated let eventSubject = PassthroughSubject<AirshipProxyEvent, Never>()
+    private nonisolated let eventSubject = PassthroughSubject<AirshipProxyEvent, Never>()
+
+    public nonisolated var pendingEventPublisher: AnyPublisher<AirshipProxyEvent, Never> {
+        eventSubject.eraseToAnyPublisher()
+    }
 
     init() {
         var escapee: AsyncStream<AirshipProxyEvent>.Continuation!


### PR DESCRIPTION
localeIdentifier can be the language ("en") or the language and country ("en-US").
But we used to use the Locale constructor with just the language parameter.
We need to handle language and/or country for the Locale override.