### PR TITLE
fixed EventEmitter. takePending

### DIFF
--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/EventEmitter.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/EventEmitter.kt
@@ -45,8 +45,7 @@ public class EventEmitter {
         synchronized(lock) {
             val result = mutableListOf<Event>()
             pendingEvents.removeAll {
-                types.contains(it.type)
-                result.add(it)
+                types.contains(it.type) && result.add(it)
             }
             return result
         }

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/EventEmitterTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/EventEmitterTest.kt
@@ -2,6 +2,8 @@ package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.android.framework.proxy.events.EventEmitter
 import com.urbanairship.json.JsonMap
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -33,6 +35,20 @@ public class EventEmitterTest {
         )
 
         assert(!emitter.hasEvents(EventType.values().toList()))
+    }
+
+    @Test
+    public fun testTakePendingFiltersByType() {
+        emitter.addEvent(TestEvent(EventType.BACKGROUND_NOTIFICATION_RESPONSE_RECEIVED))
+        emitter.addEvent(TestEvent(EventType.BACKGROUND_NOTIFICATION_RESPONSE_RECEIVED))
+        emitter.addEvent(TestEvent(EventType.FOREGROUND_NOTIFICATION_RESPONSE_RECEIVED))
+        emitter.addEvent(TestEvent(EventType.CHANNEL_CREATED))
+
+        assertTrue(emitter.takePending(emptyList()).isEmpty())
+        assertEquals(2, emitter.takePending(listOf(EventType.BACKGROUND_NOTIFICATION_RESPONSE_RECEIVED)).size)
+        assertEquals(0, emitter.takePending(listOf(EventType.BACKGROUND_NOTIFICATION_RESPONSE_RECEIVED)).size)
+        assertEquals(1, emitter.takePending(listOf(EventType.FOREGROUND_NOTIFICATION_RESPONSE_RECEIVED)).size)
+        assertEquals(1, emitter.takePending(listOf(EventType.CHANNEL_CREATED)).size)
     }
 }
 


### PR DESCRIPTION
Fixed the issue https://github.com/urbanairship/airship-mobile-framework-proxy/issues/43. thanks to @FrenkyBojler for finding the issue and proposing a solution.

Added a unit test for this case