### PR TITLE
Add LA manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [pull_request]
   
 env:
   BUNDLE_PATH: vendor/bundle
-  DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   BUNDLE_PATH: vendor/bundle
-  DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
 
 jobs:
   android:

--- a/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
+++ b/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
@@ -36,6 +36,10 @@
 		6E142EC1296F85CD00F71E23 /* TagGroupOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E142E6D296E3DEB00F71E23 /* TagGroupOperation.swift */; };
 		6E142EC2296F87DA00F71E23 /* AirshipProxyEventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E142E8D296F852300F71E23 /* AirshipProxyEventEmitter.swift */; };
 		6E1EEE772BD2D34C00B45A87 /* AirshipProxyEventEmitterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1EEE762BD2D34B00B45A87 /* AirshipProxyEventEmitterTest.swift */; };
+		6E3A02912CA60B2B00B0C5CF /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */; };
+		6E3A02942CA60B8500B0C5CF /* LiveActivityInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02932CA60B8200B0C5CF /* LiveActivityInfo.swift */; };
+		6E3A02962CA60B9200B0C5CF /* LiveActivityContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02952CA60B8F00B0C5CF /* LiveActivityContent.swift */; };
+		6E3A02982CA60BBF00B0C5CF /* LiveActivityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02972CA60BBC00B0C5CF /* LiveActivityRequest.swift */; };
 		6E4CFD25298C79FF00D131A8 /* ProxyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4CFD24298C79FF00D131A8 /* ProxyConfigTests.swift */; };
 		6E5AD11A2C82388900EDC110 /* EmbeddedEventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5AD1192C82388900EDC110 /* EmbeddedEventEmitter.swift */; };
 		6EC7553E2A4A449300851ABB /* DefaultMessageCenterUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC7553D2A4A449300851ABB /* DefaultMessageCenterUI.swift */; };
@@ -89,6 +93,10 @@
 		6E142E96296F852300F71E23 /* AirshipProxyEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AirshipProxyEvent.swift; sourceTree = "<group>"; };
 		6E142E97296F852300F71E23 /* AirshipPreferenceCenterProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AirshipPreferenceCenterProxy.swift; sourceTree = "<group>"; };
 		6E1EEE762BD2D34B00B45A87 /* AirshipProxyEventEmitterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipProxyEventEmitterTest.swift; sourceTree = "<group>"; };
+		6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
+		6E3A02932CA60B8200B0C5CF /* LiveActivityInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityInfo.swift; sourceTree = "<group>"; };
+		6E3A02952CA60B8F00B0C5CF /* LiveActivityContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityContent.swift; sourceTree = "<group>"; };
+		6E3A02972CA60BBC00B0C5CF /* LiveActivityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityRequest.swift; sourceTree = "<group>"; };
 		6E4CFD24298C79FF00D131A8 /* ProxyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyConfigTests.swift; sourceTree = "<group>"; };
 		6E5AD1192C82388900EDC110 /* EmbeddedEventEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedEventEmitter.swift; sourceTree = "<group>"; };
 		6EC7553D2A4A449300851ABB /* DefaultMessageCenterUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMessageCenterUI.swift; sourceTree = "<group>"; };
@@ -145,6 +153,7 @@
 		6E142E4E296E3A8800F71E23 /* AirshipFrameworkProxy */ = {
 			isa = PBXGroup;
 			children = (
+				6E3A028F2CA60B1C00B0C5CF /* LiveActivity */,
 				6EFB83D82979BB1F0008BEB5 /* Proxies */,
 				6E142E96296F852300F71E23 /* AirshipProxyEvent.swift */,
 				6E142E8D296F852300F71E23 /* AirshipProxyEventEmitter.swift */,
@@ -177,6 +186,17 @@
 				6E1EEE762BD2D34B00B45A87 /* AirshipProxyEventEmitterTest.swift */,
 			);
 			path = AirshipFrameworkProxyTests;
+			sourceTree = "<group>";
+		};
+		6E3A028F2CA60B1C00B0C5CF /* LiveActivity */ = {
+			isa = PBXGroup;
+			children = (
+				6E3A02972CA60BBC00B0C5CF /* LiveActivityRequest.swift */,
+				6E3A02952CA60B8F00B0C5CF /* LiveActivityContent.swift */,
+				6E3A02932CA60B8200B0C5CF /* LiveActivityInfo.swift */,
+				6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */,
+			);
+			path = LiveActivity;
 			sourceTree = "<group>";
 		};
 		6EFB83D82979BB1F0008BEB5 /* Proxies */ = {
@@ -425,6 +445,7 @@
 				6E142EC2296F87DA00F71E23 /* AirshipProxyEventEmitter.swift in Sources */,
 				6E0D94F12A7D52F400781BC7 /* AirshipFeatureFlagManagerProxy.swift in Sources */,
 				6E5AD11A2C82388900EDC110 /* EmbeddedEventEmitter.swift in Sources */,
+				6E3A02912CA60B2B00B0C5CF /* LiveActivityManager.swift in Sources */,
 				6E142EC1296F85CD00F71E23 /* TagGroupOperation.swift in Sources */,
 				6E142E98296F852300F71E23 /* AirshipProxy.swift in Sources */,
 				6E142E9B296F852300F71E23 /* AirshipLocaleProxy.swift in Sources */,
@@ -432,6 +453,8 @@
 				6E142EA3296F852300F71E23 /* AirshipProxyEvent.swift in Sources */,
 				6E142E9D296F852300F71E23 /* AirshipMessageCenterProxy.swift in Sources */,
 				6EC7553E2A4A449300851ABB /* DefaultMessageCenterUI.swift in Sources */,
+				6E3A02962CA60B9200B0C5CF /* LiveActivityContent.swift in Sources */,
+				6E3A02942CA60B8500B0C5CF /* LiveActivityInfo.swift in Sources */,
 				6E142EA2296F852300F71E23 /* AirshipContactProxy.swift in Sources */,
 				6E142E9F296F852300F71E23 /* AirshipInAppProxy.swift in Sources */,
 				6E142EA0296F852300F71E23 /* AirshipAnalyticsProxy.swift in Sources */,
@@ -439,6 +462,7 @@
 				6E142E99296F852300F71E23 /* AirshipPushProxy.swift in Sources */,
 				6E142EA1296F852300F71E23 /* AirshipActionProxy.swift in Sources */,
 				6E142E9C296F852300F71E23 /* AirshipChannelProxy.swift in Sources */,
+				6E3A02982CA60BBF00B0C5CF /* LiveActivityRequest.swift in Sources */,
 				6E142E9E296F852300F71E23 /* AirshipPrivacyManagerProxy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
+++ b/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
@@ -22,6 +22,7 @@ public enum AirshipProxyEventType: CaseIterable, Equatable, Sendable {
     case authorizedNotificationSettingsChanged
 
     case pendingEmbeddedUpdated
+    case liveActivitiesUpdated
 }
 
 public protocol AirshipProxyEvent {
@@ -35,6 +36,16 @@ struct DeepLinkEvent: AirshipProxyEvent {
 
     init(_ deepLink: URL) {
         self.body = ["deepLink": deepLink.absoluteString]
+    }
+}
+
+struct LiveActivitiesUpdatedEvent: AirshipProxyEvent {
+    let type: AirshipProxyEventType = AirshipProxyEventType.liveActivitiesUpdated
+    let body: [String: Any]
+
+    init(_ liveActivities: [LiveActivityInfo]) {
+        let info =  try? AirshipJSON.wrap(liveActivities).unWrap()
+        self.body = ["activities": info ?? []]
     }
 }
 

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityContent.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityContent.swift
@@ -1,0 +1,13 @@
+/* Copyright Airship and Contributors */
+
+#if canImport(AirshipKit)
+import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
+
+public struct LiveActivityContent: Sendable, Equatable, Codable, Hashable {
+    public var state: AirshipJSON
+    public var staleDate: Date?
+    public var relevanceScore: Double
+}

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
@@ -11,15 +11,25 @@ import ActivityKit
 public struct LiveActivityInfo: Codable, Sendable, Equatable, Hashable {
     public var id: String
     public var typeReferenceID: String
+    public var state: LiveActivityState
     public var content: LiveActivityContent
     public var attributes: AirshipJSON
 
     enum CodingKeys: String, CodingKey {
         case id
         case typeReferenceID = "typeReferenceId"
+        case state
         case content
         case attributes
     }
+}
+
+public enum LiveActivityState: String, Codable, Sendable, Equatable, Hashable {
+    case active
+    case ended
+    case dismissed
+    case stale
+    case unknown
 }
 
 extension LiveActivityInfo {
@@ -31,6 +41,7 @@ extension LiveActivityInfo {
         self.id = activity.id
         self.typeReferenceID = typeReferenceID
         self.attributes = try AirshipJSON.wrap(activity.attributes)
+        self.state = Self.state(state: activity.activityState)
         self.content = if #available(iOS 16.2, *) {
             LiveActivityContent(
               state: try AirshipJSON.wrap(activity.content.state),
@@ -43,6 +54,17 @@ extension LiveActivityInfo {
                 staleDate: nil,
                 relevanceScore: 0
             )
+        }
+    }
+
+    @available(iOS 16.1, *)
+    private static func state(state: ActivityState) -> LiveActivityState {
+        return switch(state) {
+        case .active: .active
+        case .ended: .ended
+        case .dismissed: .dismissed
+        case .stale: .stale
+        @unknown default: .unknown
         }
     }
 }

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
@@ -13,6 +13,13 @@ public struct LiveActivityInfo: Codable, Sendable, Equatable, Hashable {
     public var typeReferenceID: String
     public var content: LiveActivityContent
     public var attributes: AirshipJSON
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case typeReferenceID = "typeReferenceId"
+        case content
+        case attributes
+    }
 }
 
 extension LiveActivityInfo {

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
@@ -1,0 +1,41 @@
+/* Copyright Airship and Contributors */
+
+#if canImport(AirshipKit)
+import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
+
+import ActivityKit
+
+public struct LiveActivityInfo: Codable, Sendable, Equatable, Hashable {
+    public var id: String
+    public var typeReferenceID: String
+    public var content: LiveActivityContent
+    public var attributes: AirshipJSON
+}
+
+extension LiveActivityInfo {
+    @available(iOS 16.1, *)
+    init<T: ActivityAttributes>(
+      activity: Activity<T>,
+      typeReferenceID: String
+    ) throws {
+        self.id = activity.id
+        self.typeReferenceID = typeReferenceID
+        self.attributes = try AirshipJSON.wrap(activity.attributes)
+        self.content = if #available(iOS 16.2, *) {
+            LiveActivityContent(
+              state: try AirshipJSON.wrap(activity.content.state),
+              staleDate: activity.content.staleDate,
+              relevanceScore: activity.content.relevanceScore
+            )
+        } else {
+            LiveActivityContent(
+                state: try AirshipJSON.wrap(activity.contentState),
+                staleDate: nil,
+                relevanceScore: 0
+            )
+        }
+    }
+}

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -137,7 +137,7 @@ public actor LiveActivityManager: Sendable {
 
     public func create(_ request: LiveActivityRequest.Create) async throws -> LiveActivityInfo {
         let result = try await findEntry(typeReferenceID: request.typeReferenceID).create(request)
-        if #available(iOS 17.2, *) {} else {
+        if #unavailable(iOS 17.2) {
             await self.checkForActivities()
         }
         return result

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -250,7 +250,10 @@ extension LiveActivityManager.Entry {
             )
 
             if #available(iOS 17.2, *) {
-                await activity.update(content, timestamp: request.timestamp ?? Date())
+                await activity.update(
+                    content,
+                    timestamp: request.timestamp?.date ?? Date()
+                )
             } else {
                 await activity.update(content)
             }
@@ -285,7 +288,11 @@ extension LiveActivityManager.Entry {
             }
 
             if #available(iOS 17.2, *) {
-                await activity.end(activityContent, dismissalPolicy: dismissalPolicy, timestamp: request.timestamp ?? Date())
+                await activity.end(
+                    activityContent,
+                    dismissalPolicy: dismissalPolicy,
+                    timestamp: request.timestamp?.date ?? Date()
+                )
             } else {
                 await activity.end(activityContent, dismissalPolicy: dismissalPolicy)
             }

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -1,0 +1,325 @@
+/* Copyright Airship and Contributors */
+
+import ActivityKit
+
+#if canImport(AirshipKit)
+import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
+
+@available(iOS 16.1, *)
+public actor LiveActivityManager: Sendable {
+
+    public static let shared = LiveActivityManager()
+
+    fileprivate struct Entry {
+        let list: () throws -> [LiveActivityInfo]
+        let create: (LiveActivityRequest.Create) async throws -> LiveActivityInfo
+        let update: (LiveActivityRequest.Update) async throws -> Void
+        let end: (LiveActivityRequest.End) async throws -> Void
+
+        let pushToStartUpdates: ((@escaping @Sendable () async -> Void)) async -> Void
+        let contentUpdates: (String, (@escaping @Sendable (LiveActivityInfo) async -> Void)) async -> Void
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var initilized: Bool = false
+    private var setupTask: Task<Void, Never>? = nil
+
+    private var activityState: [String: LiveActivityInfo] = [:]
+
+    public actor Configurator {
+        fileprivate var entries: [String: Entry] = [:]
+        private var restorer: LiveActivityRestorer
+
+        init(restorer: LiveActivityRestorer) {
+            self.restorer = restorer
+        }
+
+        public func register<T: ActivityAttributes>(
+            forType type: Activity<T>.Type,
+            typeReferenceID: String,
+            airshipNameExtractor: (@Sendable (T) -> String)?
+        ) async {
+            self.entries[typeReferenceID] = Entry(
+                forType: type,
+                typeReferenceID: typeReferenceID,
+                airshipNameExtractor: airshipNameExtractor
+            )
+            await restorer.restore(forType: type)
+        }
+    }
+
+    public nonisolated func setup(setupBlock: @escaping @Sendable (Configurator) async -> Void) {
+        Task {
+            try await beginSetup(setupBlock: setupBlock)
+        }
+    }
+
+    private func beginSetup(setupBlock: @escaping @Sendable (Configurator) async -> Void) async throws {
+        guard !initilized else {
+            throw AirshipErrors.error("Already initialized")
+        }
+
+        self.initilized = true
+
+        self.setupTask = Task {
+            await withUnsafeContinuation { continuation in
+                Task {
+                    await Airship.onReady {
+                        Airship.channel.restoreLiveActivityTracking { restorer in
+                            let configurator = Configurator(restorer: restorer)
+                            await setupBlock(configurator)
+                            await self.finishSetup(configurator: configurator)
+                            continuation.resume()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func finishSetup(configurator: Configurator) async {
+        self.entries = await configurator.entries
+
+        self.entries.values.forEach { entry in
+            Task { [weak self] in
+                await entry.pushToStartUpdates { [weak self] in
+                    await self?.checkForActivities()
+                }
+            }
+        }
+    }
+
+    private func checkForActivities() async {
+        var update = false
+        let all = self.entries.values.compactMap { try? $0.list() }.joined()
+        for info in all {
+            if activityState[info.id] == nil {
+                await updated(info: info, notifyOnChange: false)
+                update = true
+            }
+        }
+
+        if (update) {
+            await notify()
+        }
+    }
+
+    private func updated(info: LiveActivityInfo, notifyOnChange: Bool) async {
+        guard activityState[info.id] != info else {
+            return
+        }
+
+        activityState[info.id] = info
+
+        if (notifyOnChange) {
+            await notify()
+        }
+    }
+
+    private func notify() async {
+        let activities = self.activityState.values.sorted { f, s in
+            return f.id.compare(s.id) == .orderedAscending
+        }
+
+        await AirshipProxyEventEmitter.shared.addEvent(LiveActivitiesUpdatedEvent(activities))
+    }
+
+    private func startWatching(_ info: LiveActivityInfo) {
+        Task { [weak self] in
+            let entry = try await self?.findEntry(typeReferenceID: info.typeReferenceID)
+            await entry?.contentUpdates(info.id, { [weak self] info in
+                await self?.updated(info: info, notifyOnChange: true)
+            })
+        }
+    }
+
+    public func create(_ request: LiveActivityRequest.Create) async throws -> LiveActivityInfo {
+        let result = try await findEntry(typeReferenceID: request.typeReferenceID).create(request)
+        if #available(iOS 17.2, *) {} else {
+            await self.checkForActivities()
+        }
+        return result
+    }
+
+    public func update(_ request: LiveActivityRequest.Update) async throws -> Void {
+        try await findEntry(typeReferenceID: request.typeReferenceID).update(request)
+    }
+
+    public func end(_ request: LiveActivityRequest.End) async throws -> Void {
+        try await findEntry(typeReferenceID: request.typeReferenceID).end(request)
+    }
+
+    public func list(_ request: LiveActivityRequest.List) async throws -> [LiveActivityInfo] {
+        return try await findEntry(typeReferenceID: request.typeReferenceID).list()
+    }
+
+    private func findEntry(typeReferenceID: String) async throws -> Entry {
+        await setupTask?.value
+        guard let entry = self.entries[typeReferenceID] else {
+            throw AirshipErrors.error("Missing entry for typeReferenceID \(typeReferenceID)")
+        }
+        return entry
+    }
+}
+
+
+@available(iOS 16.1, *)
+extension LiveActivityManager.Entry {
+    init<T: ActivityAttributes>(
+        forType type: Activity<T>.Type,
+        typeReferenceID: String,
+        airshipNameExtractor: (@Sendable (T) -> String)?
+    ) {
+
+        self.pushToStartUpdates = { callback in
+            if #available(iOS 17.2, *) {
+                for await _ in type.pushToStartTokenUpdates {
+                    await callback()
+                }
+            }
+        }
+
+        self.contentUpdates = { id, callback in
+            guard let activity = type.activities.first(where: { $0.id == id }) else {
+               return
+            }
+
+            if #available(iOS 16.2, *) {
+                for await _ in activity.contentUpdates {
+                    guard let updated = type.activities.first(where: { $0.id == id }) else {
+                        return
+                    }
+
+                    if let info = try? LiveActivityInfo(activity: updated, typeReferenceID: typeReferenceID) {
+                        await callback(info)
+                    }
+                }
+            } else {
+                for await _ in activity.contentStateUpdates {
+                    guard let updated = type.activities.first(where: { $0.id == id }) else {
+                        return
+                    }
+
+                    if let info = try? LiveActivityInfo(activity: updated, typeReferenceID: typeReferenceID) {
+                        await callback(info)
+                    }
+                }
+            }
+        }
+
+        self.end = { request in
+            guard let activity = type.activities.first(where: { $0.id == request.activityID }) else {
+                throw AirshipErrors.error("No activity found with activityID \(request.activityID) typeReferenceID \(typeReferenceID)")
+            }
+            try await Self.endActivity(activity, request: request)
+        }
+
+        self.list = {
+            return try type.activities.map { activity in
+                try LiveActivityInfo(activity: activity, typeReferenceID: typeReferenceID)
+            }
+        }
+
+        self.update = { request in
+            guard let activity = type.activities.first(where: { $0.id == request.activityID }) else {
+                throw AirshipErrors.error("No activity found with activityID \(request.activityID) typeReferenceID \(typeReferenceID)")
+            }
+
+            try await Self.updateActivity(activity, request: request)
+        }
+
+        self.create = { request in
+            let activity: Activity<T> = try Self.createActivity(request: request)
+            if let airshipName = airshipNameExtractor?(activity.attributes) {
+                Airship.channel.trackLiveActivity(activity, name: airshipName)
+            }
+
+            return try LiveActivityInfo(activity: activity, typeReferenceID: typeReferenceID)
+        }
+    }
+
+    private static func updateActivity<T: ActivityAttributes>(
+        _ activity: Activity<T>,
+        request: LiveActivityRequest.Update
+    ) async throws {
+        let decodedContentState: T.ContentState = try request.content.state.decode()
+        if #available(iOS 16.2, *) {
+            let content = ActivityContent(
+                state: decodedContentState,
+                staleDate: request.content.staleDate,
+                relevanceScore: request.content.relevanceScore
+            )
+
+            if #available(iOS 17.2, *) {
+                await activity.update(content, timestamp: request.timestamp ?? Date())
+            } else {
+                await activity.update(content)
+            }
+        } else {
+            await activity.update(using: decodedContentState)
+        }
+    }
+
+    private static func endActivity<T: ActivityAttributes>(
+        _ activity: Activity<T>,
+        request: LiveActivityRequest.End
+    ) async throws {
+
+        let dismissalPolicy: ActivityUIDismissalPolicy = switch(request.dismissalPolicy ??  .default) {
+        case .after(let date): .after(date)
+        case .default: .default
+        case .immediate: .immediate
+        }
+
+        if #available(iOS 16.2, *) {
+            let activityContent: ActivityContent<T.ContentState>? = if let content = request.content {
+                ActivityContent(
+                    state: try content.state.decode(),
+                    staleDate: content.staleDate,
+                    relevanceScore: content.relevanceScore
+                )
+            } else {
+                nil
+            }
+
+            if #available(iOS 17.2, *) {
+                await activity.end(activityContent, dismissalPolicy: dismissalPolicy, timestamp: request.timestamp ?? Date())
+            } else {
+                await activity.end(activityContent, dismissalPolicy: dismissalPolicy)
+            }
+        } else {
+            await activity.end(
+                using: try request.content?.state.decode(),
+                dismissalPolicy: dismissalPolicy
+            )
+        }
+    }
+
+    private static func createActivity<T: ActivityAttributes>(
+        request: LiveActivityRequest.Create
+    ) throws -> Activity<T> {
+        let decodedAttributes: T = try request.attributes.decode()
+        let decodedContentState: T.ContentState = try request.content.state.decode()
+
+        if #available(iOS 16.2, *) {
+            return try Activity.request(
+                attributes: decodedAttributes,
+                content: ActivityContent(
+                    state: decodedContentState,
+                    staleDate: request.content.staleDate,
+                    relevanceScore: request.content.relevanceScore
+                ),
+                pushType: .token
+            )
+        } else {
+            return try Activity.request(
+                attributes: decodedAttributes,
+                contentState: decodedContentState,
+                pushType: .token
+            )
+        }
+    }
+}

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -249,14 +249,7 @@ extension LiveActivityManager.Entry {
                 relevanceScore: request.content.relevanceScore
             )
 
-            if #available(iOS 17.2, *) {
-                await activity.update(
-                    content,
-                    timestamp: request.timestamp?.date ?? Date()
-                )
-            } else {
-                await activity.update(content)
-            }
+            await activity.update(content)
         } else {
             await activity.update(using: decodedContentState)
         }
@@ -287,15 +280,7 @@ extension LiveActivityManager.Entry {
                 nil
             }
 
-            if #available(iOS 17.2, *) {
-                await activity.end(
-                    activityContent,
-                    dismissalPolicy: dismissalPolicy,
-                    timestamp: request.timestamp?.date ?? Date()
-                )
-            } else {
-                await activity.end(activityContent, dismissalPolicy: dismissalPolicy)
-            }
+            await activity.end(activityContent, dismissalPolicy: dismissalPolicy)
         } else {
             await activity.end(
                 using: try request.content?.state.decode(),

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -10,6 +10,10 @@ public struct LiveActivityRequest: Sendable, Equatable {
     public struct List: Sendable, Equatable, Codable {
         public var typeReferenceID: String
 
+        enum CodingKeys: String, CodingKey {
+            case typeReferenceID = "typeReferenceId"
+        }
+
         public init(typeReferenceID: String) {
             self.typeReferenceID = typeReferenceID
         }
@@ -20,6 +24,15 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var typeReferenceID: String
         public var content: LiveActivityContent
         public var timestamp: Date?
+
+
+        enum CodingKeys: String, CodingKey {
+            case activityID
+            case typeReferenceID = "typeReferenceId"
+            case content
+            case timestamp
+        }
+
 
         public init(activityID: String, typeReferenceID: String, content: LiveActivityContent, timestamp: Date? = nil) {
             self.activityID = activityID
@@ -36,6 +49,14 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var dismissalPolicy: DismissalPolicy?
         public var timestamp: Date?
 
+        enum CodingKeys: String, CodingKey {
+            case activityID
+            case typeReferenceID = "typeReferenceId"
+            case content
+            case dismissalPolicy
+            case timestamp
+        }
+
         public init(activityID: String, typeReferenceID: String, content: LiveActivityContent? = nil, dismissalPolicy: DismissalPolicy? = nil, timestamp: Date? = nil) {
             self.activityID = activityID
             self.typeReferenceID = typeReferenceID
@@ -50,6 +71,11 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var content: LiveActivityContent
         public var attributes: AirshipJSON
 
+        enum CodingKeys: String, CodingKey {
+            case typeReferenceID = "typeReferenceId"
+            case content
+            case attributes
+        }
         public init(typeReferenceID: String, content: LiveActivityContent, attributes: AirshipJSON) {
             self.typeReferenceID = typeReferenceID
             self.content = content

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -1,0 +1,104 @@
+/* Copyright Airship and Contributors */
+
+#if canImport(AirshipKit)
+import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
+
+public struct LiveActivityRequest: Sendable, Equatable {
+    public struct List: Sendable, Equatable, Codable {
+        public var typeReferenceID: String
+
+        public init(typeReferenceID: String) {
+            self.typeReferenceID = typeReferenceID
+        }
+    }
+
+    public struct Update: Sendable, Equatable, Codable {
+        public var activityID: String
+        public var typeReferenceID: String
+        public var content: LiveActivityContent
+        public var timestamp: Date?
+
+        public init(activityID: String, typeReferenceID: String, content: LiveActivityContent, timestamp: Date? = nil) {
+            self.activityID = activityID
+            self.typeReferenceID = typeReferenceID
+            self.content = content
+            self.timestamp = timestamp
+        }
+    }
+
+    public struct End: Sendable, Equatable, Codable {
+        public var activityID: String
+        public var typeReferenceID: String
+        public var content: LiveActivityContent?
+        public var dismissalPolicy: DismissalPolicy?
+        public var timestamp: Date?
+
+        public init(activityID: String, typeReferenceID: String, content: LiveActivityContent? = nil, dismissalPolicy: DismissalPolicy? = nil, timestamp: Date? = nil) {
+            self.activityID = activityID
+            self.typeReferenceID = typeReferenceID
+            self.content = content
+            self.dismissalPolicy = dismissalPolicy
+            self.timestamp = timestamp
+        }
+    }
+
+    public struct Create: Sendable, Equatable, Codable {
+        public var typeReferenceID: String
+        public var content: LiveActivityContent
+        public var attributes: AirshipJSON
+
+        public init(typeReferenceID: String, content: LiveActivityContent, attributes: AirshipJSON) {
+            self.typeReferenceID = typeReferenceID
+            self.content = content
+            self.attributes = attributes
+        }
+    }
+
+    public enum DismissalPolicy: Sendable, Equatable, Codable {
+        case immediate
+        case `default`
+        case after(date: Date)
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case date
+        }
+
+        private enum DismissalType: String, Codable {
+            case immediate
+            case `default` = "default"
+            case after
+        }
+
+        public init(from decoder: any Decoder) throws {
+            var container = try decoder.container(keyedBy: CodingKeys.self)
+            var type = try container.decode(DismissalType.self, forKey: .type)
+            switch (type) {
+            case .after:
+                self = .after(date: try container.decode(Date.self, forKey: .date))
+            case .immediate:
+                self = .immediate
+            case .default:
+                self = .default
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch (self) {
+            case .after(let date):
+                try container.encode(DismissalType.after, forKey: .type)
+                try container.encode(date, forKey: .date)
+            case .immediate:
+                try container.encode(DismissalType.immediate, forKey: .type)
+            case .default:
+                try container.encode(DismissalType.default, forKey: .type)
+            }
+        }
+    }
+}
+
+

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -27,7 +27,7 @@ public struct LiveActivityRequest: Sendable, Equatable {
 
 
         enum CodingKeys: String, CodingKey {
-            case activityID
+            case activityID = "activityId"
             case typeReferenceID = "typeReferenceId"
             case content
         }
@@ -51,7 +51,7 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var dismissalPolicy: DismissalPolicy?
 
         enum CodingKeys: String, CodingKey {
-            case activityID
+            case activityID = "activityId"
             case typeReferenceID = "typeReferenceId"
             case content
             case dismissalPolicy

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -8,27 +8,6 @@ import AirshipCore
 
 public struct LiveActivityRequest: Sendable, Equatable {
 
-    public struct Timestamp: Codable, Sendable, Equatable, Hashable {
-        public let date: Date
-
-        public init(date: Date) {
-            self.date = date
-        }
-
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.singleValueContainer()
-            try container.encode(AirshipDateFormatter.string(fromDate: date, format: .iso))
-        }
-
-        public init(from decoder: any Decoder) throws {
-            var value = try decoder.singleValueContainer().decode(String.self)
-            guard let date = AirshipDateFormatter.date(fromISOString: value) else {
-                throw AirshipErrors.error("Invalid date")
-            }
-            self.date = date
-        }
-    }
-
     public struct List: Sendable, Equatable, Codable {
         public var typeReferenceID: String
 
@@ -45,27 +24,23 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var activityID: String
         public var typeReferenceID: String
         public var content: LiveActivityContent
-        public var timestamp: Timestamp?
 
 
         enum CodingKeys: String, CodingKey {
             case activityID
             case typeReferenceID = "typeReferenceId"
             case content
-            case timestamp
         }
 
 
         public init(
             activityID: String,
             typeReferenceID: String,
-            content: LiveActivityContent,
-            timestamp: Timestamp? = nil
+            content: LiveActivityContent
         ) {
             self.activityID = activityID
             self.typeReferenceID = typeReferenceID
             self.content = content
-            self.timestamp = timestamp
         }
     }
 
@@ -74,28 +49,24 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var typeReferenceID: String
         public var content: LiveActivityContent?
         public var dismissalPolicy: DismissalPolicy?
-        public var timestamp: Timestamp?
 
         enum CodingKeys: String, CodingKey {
             case activityID
             case typeReferenceID = "typeReferenceId"
             case content
             case dismissalPolicy
-            case timestamp
         }
 
         public init(
             activityID: String,
             typeReferenceID: String,
             content: LiveActivityContent? = nil,
-            dismissalPolicy: DismissalPolicy? = nil,
-            timestamp: Timestamp? = nil
+            dismissalPolicy: DismissalPolicy? = nil
         ) {
             self.activityID = activityID
             self.typeReferenceID = typeReferenceID
             self.content = content
             self.dismissalPolicy = dismissalPolicy
-            self.timestamp = timestamp
         }
     }
 

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -7,6 +7,28 @@ import AirshipCore
 #endif
 
 public struct LiveActivityRequest: Sendable, Equatable {
+
+    public struct Timestamp: Codable, Sendable, Equatable, Hashable {
+        public let date: Date
+
+        public init(date: Date) {
+            self.date = date
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(AirshipDateFormatter.string(fromDate: date, format: .iso))
+        }
+
+        public init(from decoder: any Decoder) throws {
+            var value = try decoder.singleValueContainer().decode(String.self)
+            guard let date = AirshipDateFormatter.date(fromISOString: value) else {
+                throw AirshipErrors.error("Invalid date")
+            }
+            self.date = date
+        }
+    }
+
     public struct List: Sendable, Equatable, Codable {
         public var typeReferenceID: String
 
@@ -23,7 +45,7 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var activityID: String
         public var typeReferenceID: String
         public var content: LiveActivityContent
-        public var timestamp: Date?
+        public var timestamp: Timestamp?
 
 
         enum CodingKeys: String, CodingKey {
@@ -34,7 +56,12 @@ public struct LiveActivityRequest: Sendable, Equatable {
         }
 
 
-        public init(activityID: String, typeReferenceID: String, content: LiveActivityContent, timestamp: Date? = nil) {
+        public init(
+            activityID: String,
+            typeReferenceID: String,
+            content: LiveActivityContent,
+            timestamp: Timestamp? = nil
+        ) {
             self.activityID = activityID
             self.typeReferenceID = typeReferenceID
             self.content = content
@@ -47,7 +74,7 @@ public struct LiveActivityRequest: Sendable, Equatable {
         public var typeReferenceID: String
         public var content: LiveActivityContent?
         public var dismissalPolicy: DismissalPolicy?
-        public var timestamp: Date?
+        public var timestamp: Timestamp?
 
         enum CodingKeys: String, CodingKey {
             case activityID
@@ -57,7 +84,13 @@ public struct LiveActivityRequest: Sendable, Equatable {
             case timestamp
         }
 
-        public init(activityID: String, typeReferenceID: String, content: LiveActivityContent? = nil, dismissalPolicy: DismissalPolicy? = nil, timestamp: Date? = nil) {
+        public init(
+            activityID: String,
+            typeReferenceID: String,
+            content: LiveActivityContent? = nil,
+            dismissalPolicy: DismissalPolicy? = nil,
+            timestamp: Timestamp? = nil
+        ) {
             self.activityID = activityID
             self.typeReferenceID = typeReferenceID
             self.content = content
@@ -76,7 +109,11 @@ public struct LiveActivityRequest: Sendable, Equatable {
             case content
             case attributes
         }
-        public init(typeReferenceID: String, content: LiveActivityContent, attributes: AirshipJSON) {
+        public init(
+            typeReferenceID: String,
+            content: LiveActivityContent,
+            attributes: AirshipJSON
+        ) {
             self.typeReferenceID = typeReferenceID
             self.content = content
             self.attributes = attributes
@@ -100,8 +137,8 @@ public struct LiveActivityRequest: Sendable, Equatable {
         }
 
         public init(from decoder: any Decoder) throws {
-            var container = try decoder.container(keyedBy: CodingKeys.self)
-            var type = try container.decode(DismissalType.self, forKey: .type)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(DismissalType.self, forKey: .type)
             switch (type) {
             case .after:
                 self = .after(date: try container.decode(Date.self, forKey: .date))


### PR DESCRIPTION
Trying to make it super easy to manage LA from a framework. They will still have to register LA natively but I think I got it down to one call:

```
    if #available(iOS 16.1, *) {
      LiveActivityManager.shared.setup { configurator in
          configurator.register(forType: Activity<DeliveryAttributes> , typeReferenceID: "Delivery") { attributes in
              // Track this property as the Airship name for updates
              attributes.orderNumber
            }
        }
    }
    
```

You can then start, end, update, and listen for changes. The `typeReferenceID` maps the type from JS to the native type.