### PR TITLE
Add class loaders

### DIFF
--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -16,16 +16,7 @@ Pod::Spec.new do |s|
    s.swift_version           = "5.0"
    s.source_files            = "ios/AirshipFrameworkProxy/**/*.{h,m,swift}"
    s.dependency                'Airship', "18.9.2"
-   s.default_subspecs        = ["Loader", "Proxy"]
-
-   s.subspec "Loader" do |loader|
-      loader.source_files = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}'
-    end
-   
-   
-    s.subspec "Proxy" do |proxy|
-      proxy.source_files = 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'
-    end   
+   s.source_files            = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}', 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'
 end
 
 

--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -16,4 +16,16 @@ Pod::Spec.new do |s|
    s.swift_version           = "5.0"
    s.source_files            = "ios/AirshipFrameworkProxy/**/*.{h,m,swift}"
    s.dependency                'Airship', "18.9.2"
+   s.default_subspecs        = ["Loader", "Proxy"]
+
+   s.subspec "Loader" do |loader|
+      loader.source_files = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}'
+    end
+   
+   
+    s.subspec "Proxy" do |proxy|
+      proxy.source_files = 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'
+    end   
 end
+
+

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "AirshipFrameworkProxy",
+            name: "AirshipFrameworkProxyBase",
             dependencies: [
                 .product(name: "AirshipCore", package: "ios-library"),
                 .product(name: "AirshipMessageCenter", package: "ios-library"),
@@ -31,6 +31,12 @@ let package = Package(
             exclude: [
                 "AirshipFrameworkProxy.h"
             ]
+        ),
+         .target(
+            name: "AirshipFrameworkProxy",
+            dependencies: [.target(name: "AirshipFrameworkProxyBase")],
+            path: "ios/AirshipFrameworkProxyLoader",
+            publicHeadersPath: "Public"
         )
     ]
 )

--- a/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
+++ b/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		6E5AD11A2C82388900EDC110 /* EmbeddedEventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5AD1192C82388900EDC110 /* EmbeddedEventEmitter.swift */; };
 		6EC7553E2A4A449300851ABB /* DefaultMessageCenterUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC7553D2A4A449300851ABB /* DefaultMessageCenterUI.swift */; };
 		6EC755402A4A494C00851ABB /* NotificationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC7553F2A4A494C00851ABB /* NotificationStatus.swift */; };
+		6ED117AF2CA750F400C41C56 /* AirshipFrameworkProxyLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117AE2CA750F000C41C56 /* AirshipFrameworkProxyLoader.swift */; };
+		6ED117B22CA75D1500C41C56 /* AirshipPluginLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117B12CA75D0F00C41C56 /* AirshipPluginLoaderProtocol.swift */; };
+		6ED117B52CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117B42CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift */; };
 		6EFB83DA2979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFB83D92979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift */; };
 		842981FF2AA10D6600456BDB /* TagOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842981FE2AA10D6600456BDB /* TagOperationTest.swift */; };
 		8443CF342A97ADB3000589B8 /* TagOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8443CF332A97ADB3000589B8 /* TagOperation.swift */; };
@@ -101,6 +104,11 @@
 		6E5AD1192C82388900EDC110 /* EmbeddedEventEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedEventEmitter.swift; sourceTree = "<group>"; };
 		6EC7553D2A4A449300851ABB /* DefaultMessageCenterUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMessageCenterUI.swift; sourceTree = "<group>"; };
 		6EC7553F2A4A494C00851ABB /* NotificationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStatus.swift; sourceTree = "<group>"; };
+		6ED117A82CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UAirshipFrameworkProxyLoader.h; sourceTree = "<group>"; };
+		6ED117A92CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UAirshipFrameworkProxyLoader.m; sourceTree = "<group>"; };
+		6ED117AE2CA750F000C41C56 /* AirshipFrameworkProxyLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipFrameworkProxyLoader.swift; sourceTree = "<group>"; };
+		6ED117B12CA75D0F00C41C56 /* AirshipPluginLoaderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipPluginLoaderProtocol.swift; sourceTree = "<group>"; };
+		6ED117B42CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipPluginExtenderProtocol.swift; sourceTree = "<group>"; };
 		6EFB83D92979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedSubscriptionListOperation.swift; sourceTree = "<group>"; };
 		842981FE2AA10D6600456BDB /* TagOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOperationTest.swift; sourceTree = "<group>"; };
 		8443CF332A97ADB3000589B8 /* TagOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOperation.swift; sourceTree = "<group>"; };
@@ -133,6 +141,7 @@
 		6E142E42296E3A8800F71E23 = {
 			isa = PBXGroup;
 			children = (
+				6ED117AA2CA74F9700C41C56 /* AirshipFrameworkProxyLoader */,
 				6E142E4E296E3A8800F71E23 /* AirshipFrameworkProxy */,
 				6E142E58296E3A8800F71E23 /* AirshipFrameworkProxyTests */,
 				6E142E4D296E3A8800F71E23 /* Products */,
@@ -153,6 +162,7 @@
 		6E142E4E296E3A8800F71E23 /* AirshipFrameworkProxy */ = {
 			isa = PBXGroup;
 			children = (
+				6ED117B32CA75D1B00C41C56 /* Loader */,
 				6E3A028F2CA60B1C00B0C5CF /* LiveActivity */,
 				6EFB83D82979BB1F0008BEB5 /* Proxies */,
 				6E142E96296F852300F71E23 /* AirshipProxyEvent.swift */,
@@ -197,6 +207,33 @@
 				6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */,
 			);
 			path = LiveActivity;
+			sourceTree = "<group>";
+		};
+		6ED117AA2CA74F9700C41C56 /* AirshipFrameworkProxyLoader */ = {
+			isa = PBXGroup;
+			children = (
+				6ED117B02CA75CD400C41C56 /* Public */,
+				6ED117A92CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.m */,
+			);
+			path = AirshipFrameworkProxyLoader;
+			sourceTree = "<group>";
+		};
+		6ED117B02CA75CD400C41C56 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				6ED117A82CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.h */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		6ED117B32CA75D1B00C41C56 /* Loader */ = {
+			isa = PBXGroup;
+			children = (
+				6ED117B12CA75D0F00C41C56 /* AirshipPluginLoaderProtocol.swift */,
+				6ED117B42CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift */,
+				6ED117AE2CA750F000C41C56 /* AirshipFrameworkProxyLoader.swift */,
+			);
+			path = Loader;
 			sourceTree = "<group>";
 		};
 		6EFB83D82979BB1F0008BEB5 /* Proxies */ = {
@@ -452,13 +489,16 @@
 				8443CF342A97ADB3000589B8 /* TagOperation.swift in Sources */,
 				6E142EA3296F852300F71E23 /* AirshipProxyEvent.swift in Sources */,
 				6E142E9D296F852300F71E23 /* AirshipMessageCenterProxy.swift in Sources */,
+				6ED117B22CA75D1500C41C56 /* AirshipPluginLoaderProtocol.swift in Sources */,
 				6EC7553E2A4A449300851ABB /* DefaultMessageCenterUI.swift in Sources */,
 				6E3A02962CA60B9200B0C5CF /* LiveActivityContent.swift in Sources */,
 				6E3A02942CA60B8500B0C5CF /* LiveActivityInfo.swift in Sources */,
 				6E142EA2296F852300F71E23 /* AirshipContactProxy.swift in Sources */,
 				6E142E9F296F852300F71E23 /* AirshipInAppProxy.swift in Sources */,
 				6E142EA0296F852300F71E23 /* AirshipAnalyticsProxy.swift in Sources */,
+				6ED117AF2CA750F400C41C56 /* AirshipFrameworkProxyLoader.swift in Sources */,
 				6E142EA4296F852300F71E23 /* AirshipPreferenceCenterProxy.swift in Sources */,
+				6ED117B52CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift in Sources */,
 				6E142E99296F852300F71E23 /* AirshipPushProxy.swift in Sources */,
 				6E142EA1296F852300F71E23 /* AirshipActionProxy.swift in Sources */,
 				6E142E9C296F852300F71E23 /* AirshipChannelProxy.swift in Sources */,

--- a/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
+++ b/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		6ED117AF2CA750F400C41C56 /* AirshipFrameworkProxyLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117AE2CA750F000C41C56 /* AirshipFrameworkProxyLoader.swift */; };
 		6ED117B22CA75D1500C41C56 /* AirshipPluginLoaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117B12CA75D0F00C41C56 /* AirshipPluginLoaderProtocol.swift */; };
 		6ED117B52CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117B42CA75D2300C41C56 /* AirshipPluginExtenderProtocol.swift */; };
+		6ED117D72CA7760A00C41C56 /* UAirshipFrameworkProxyLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED117A92CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.m */; };
+		6ED117D82CA7761300C41C56 /* UAirshipFrameworkProxyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ED117A82CA74F9100C41C56 /* UAirshipFrameworkProxyLoader.h */; };
 		6EFB83DA2979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFB83D92979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift */; };
 		842981FF2AA10D6600456BDB /* TagOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842981FE2AA10D6600456BDB /* TagOperationTest.swift */; };
 		8443CF342A97ADB3000589B8 /* TagOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8443CF332A97ADB3000589B8 /* TagOperation.swift */; };
@@ -282,6 +284,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6ED117D82CA7761300C41C56 /* UAirshipFrameworkProxyLoader.h in Headers */,
 				6E142E5B296E3A8800F71E23 /* AirshipFrameworkProxy.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -482,6 +485,7 @@
 				6E142EC2296F87DA00F71E23 /* AirshipProxyEventEmitter.swift in Sources */,
 				6E0D94F12A7D52F400781BC7 /* AirshipFeatureFlagManagerProxy.swift in Sources */,
 				6E5AD11A2C82388900EDC110 /* EmbeddedEventEmitter.swift in Sources */,
+				6ED117D72CA7760A00C41C56 /* UAirshipFrameworkProxyLoader.m in Sources */,
 				6E3A02912CA60B2B00B0C5CF /* LiveActivityManager.swift in Sources */,
 				6E142EC1296F85CD00F71E23 /* TagGroupOperation.swift in Sources */,
 				6E142E98296F852300F71E23 /* AirshipProxy.swift in Sources */,

--- a/ios/AirshipFrameworkProxy/Loader/AirshipFrameworkProxyLoader.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipFrameworkProxyLoader.swift
@@ -1,0 +1,36 @@
+/* Copyright Airship and Contributors */
+
+import UIKit
+
+#if canImport(AirshipKit)
+import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
+
+@objc
+@MainActor
+public class AirshipFrameworkProxyLoader: NSObject {
+    private static let pluginLoaderClass = "AirshipPluginLoader"
+    private static let extenderClass = "AirshipPluginExtender"
+
+    private static var pluginLoader: AirshipPluginLoaderProtocol?
+    private static var extender: AirshipPluginExtenderProtocol?
+
+    @objc
+    public static func onLoad() {
+        if let classFromString =  NSClassFromString(self.extenderClass) as? AirshipPluginExtenderProtocol.Type {
+            Airship.onReady {
+                classFromString.onAirshipReady()
+            }
+        }
+    }
+
+    @objc
+    public static func onApplicationDidFinishLaunching(launchOptions: [UIApplication.LaunchOptionsKey : Any]?) {
+        if let classFromString =  NSClassFromString(self.pluginLoaderClass) as? AirshipPluginLoaderProtocol.Type {
+            classFromString.onApplicationDidFinishLaunching(launchOptions: launchOptions)
+        }
+    }
+}
+

--- a/ios/AirshipFrameworkProxy/Loader/AirshipPluginExtenderProtocol.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipPluginExtenderProtocol.swift
@@ -1,0 +1,8 @@
+/* Copyright Airship and Contributors */
+
+import UIKit
+
+public protocol AirshipPluginExtenderProtocol: NSObject {
+    @MainActor
+    static func onAirshipReady()
+}

--- a/ios/AirshipFrameworkProxy/Loader/AirshipPluginLoaderProtocol.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipPluginLoaderProtocol.swift
@@ -1,0 +1,8 @@
+/* Copyright Airship and Contributors */
+
+import UIKit
+
+public protocol AirshipPluginLoaderProtocol: NSObject {
+    @MainActor
+    static func onApplicationDidFinishLaunching(launchOptions: [UIApplication.LaunchOptionsKey : Any]?)
+}

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
@@ -58,6 +58,7 @@ public class AirshipPreferenceCenterProxy {
 }
 
 protocol AirshipPreferenceCenterProtocol: AnyObject {
+    @MainActor
     func open(_ preferenceCenterID: String)
     func jsonConfig(preferenceCenterID: String) async throws -> Data
 }

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
@@ -58,7 +58,6 @@ public class AirshipPreferenceCenterProxy {
 }
 
 protocol AirshipPreferenceCenterProtocol: AnyObject {
-    @MainActor
     func open(_ preferenceCenterID: String)
     func jsonConfig(preferenceCenterID: String) async throws -> Data
 }

--- a/ios/AirshipFrameworkProxyLoader/Public/UAirshipFrameworkProxyLoader.h
+++ b/ios/AirshipFrameworkProxyLoader/Public/UAirshipFrameworkProxyLoader.h
@@ -1,0 +1,9 @@
+/* Copyright Urban Airship and Contributors */
+
+@import Foundation;
+
+
+@interface UAirshipFrameworkProxyLoader: NSObject
+
+
+@end

--- a/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
+++ b/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
@@ -7,7 +7,7 @@
 #elif __has_include("AirshipFrameworkProxy-Swift.h")
 #import "AirshipFrameworkProxy-Swift.h"
 #else
-@import AirshipFrameworkProxy;
+@import AirshipFrameworkProxyBase;
 #endif
 
 @implementation UAirshipFrameworkProxyLoader

--- a/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
+++ b/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
@@ -1,0 +1,28 @@
+/* Copyright Airship and Contributors */
+
+#import "UAirshipFrameworkProxyLoader.h"
+
+#if __has_include("AirshipFrameworkProxy/AirshipFrameworkProxy-Swift.h")
+#import <AirshipFrameworkProxy/AirshipFrameworkProxy-Swift.h>
+#elif __has_include("AirshipFrameworkProxy-Swift.h")
+#import "AirshipFrameworkProxy-Swift.h"
+#else
+@import AirshipFrameworkProxy;
+#endif
+
+@implementation UAirshipFrameworkProxyLoader
+
++ (void)load {
+    [AirshipFrameworkProxyLoader onLoad];
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserverForName:UIApplicationDidFinishLaunchingNotification
+                        object:nil
+                         queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+
+        [AirshipFrameworkProxyLoader onApplicationDidFinishLaunchingWithLaunchOptions:note.userInfo];
+    }];
+}
+
+@end
+


### PR DESCRIPTION
Adds two loaders into the proxy to make dev easier. The loader will find classes with the names:
- AirshipPluginLoader: all the frameworks will add this instead of a custom loader
- AirshipPluginExtender: This is for devs to use to wire in or change things on Airship. Gives them an `onReady` callback. Needed to make LA easier