### PR TITLE
Android Add hybrid app hooks

### DIFF
--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipListener.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipListener.kt
@@ -71,13 +71,15 @@ internal class AirshipListener(
 
     override fun onNotificationPosted(notificationInfo: NotificationInfo) {
         eventEmitter.addEvent(PushReceivedEvent(notificationInfo, isAppForegrounded))
+        AirshipPluginForwardListeners.notificationListener?.onNotificationPosted(notificationInfo)
     }
 
     override fun onNotificationOpened(notificationInfo: NotificationInfo): Boolean {
         eventEmitter.addEvent(
             NotificationResponseEvent(notificationInfo, null)
         )
-        return false
+
+        return AirshipPluginForwardListeners.notificationListener?.onNotificationOpened(notificationInfo) ?: false
     }
 
     override fun onNotificationForegroundAction(
@@ -87,7 +89,7 @@ internal class AirshipListener(
         eventEmitter.addEvent(
             NotificationResponseEvent(notificationInfo, notificationActionButtonInfo)
         )
-        return false
+        return AirshipPluginForwardListeners.notificationListener?.onNotificationForegroundAction(notificationInfo, notificationActionButtonInfo) ?: false
     }
 
     override fun onNotificationBackgroundAction(
@@ -97,12 +99,18 @@ internal class AirshipListener(
         eventEmitter.addEvent(
             NotificationResponseEvent(notificationInfo, notificationActionButtonInfo)
         )
+        AirshipPluginForwardListeners.notificationListener?.onNotificationBackgroundAction(notificationInfo, notificationActionButtonInfo)
     }
 
-    override fun onNotificationDismissed(notificationInfo: NotificationInfo) {}
+    override fun onNotificationDismissed(notificationInfo: NotificationInfo) {
+        AirshipPluginForwardListeners.notificationListener?.onNotificationDismissed(notificationInfo)
+    }
 
     override fun onDeepLink(deepLink: String): Boolean {
-        eventEmitter.addEvent(DeepLinkEvent(deepLink))
+        if (AirshipPluginForwardListeners.deepLinkListener?.onDeepLink(deepLink) != true) {
+            eventEmitter.addEvent(DeepLinkEvent(deepLink))
+        }
+
         return true
     }
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipPluginForwardListeners.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipPluginForwardListeners.kt
@@ -1,0 +1,21 @@
+/* Copyright Urban Airship and Contributors */
+
+package com.urbanairship.android.framework.proxy
+
+import com.urbanairship.actions.DeepLinkListener
+import com.urbanairship.push.NotificationListener
+
+/**
+ * Optional forward listeners for the plugin.
+ */
+public object AirshipPluginForwardListeners {
+    /**
+     * Deep link listener
+     */
+    public var deepLinkListener: DeepLinkListener? = null
+
+    /**
+     * Notification Listener
+     */
+    public var notificationListener: NotificationListener? = null
+}

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshpPluginExtender.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshpPluginExtender.kt
@@ -3,6 +3,7 @@
 package com.urbanairship.android.framework.proxy
 
 import android.content.Context
+import com.urbanairship.AirshipConfigOptions
 import com.urbanairship.UAirship
 
 /**
@@ -19,4 +20,19 @@ public interface AirshipPluginExtender {
      * @param airship The airship instance.
      */
     public fun onAirshipReady(context: Context, airship: UAirship)
+
+    /**
+     * Used to extend the AirshipConfig. The configBuilder will have the default config applied from the properties file if available,
+     * any config defined by the module.
+     * @param context The application context.
+     * @param configBuilder The config builder
+     * @return The config builder.
+     */
+    public fun extendConfig(
+        context: Context,
+        configBuilder: AirshipConfigOptions.Builder
+    ): AirshipConfigOptions.Builder {
+        return configBuilder
+    }
 }
+


### PR DESCRIPTION
Adds ability to modify config programmatically and set forward listeners.

This will have to be another major rev to the proxy and frameworks since the airship extender optional method does not bind to Java. There are some flags to make defaults work but it requires special compiler flags, not sure if we want to go down that route. 

