### PR TITLE
Bump Airship to 18.12.1 in .podspec

### DIFF
--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
    s.requires_arc            = true
    s.swift_version           = "5.0"
    s.source_files            = "ios/AirshipFrameworkProxy/**/*.{h,m,swift}"
-   s.dependency                'Airship', "18.11.1"
+   s.dependency                'Airship', "18.12.1"
    s.source_files            = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}', 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'
 end
 


### PR DESCRIPTION
Bumped the version from `18.11.1` to `18.12.1` in the `AirshipFrameworkProxy.podspec` file 