### PR TITLE
MOBILE-4771: Research Flutter SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         ),
          .target(
             name: "AirshipFrameworkProxyLoader",
-            dependencies: [.target(name: "AirshipFrameworkProxyBase")],
+            dependencies: [.target(name: "AirshipFrameworkProxy")],
             path: "ios/AirshipFrameworkProxyLoader",
             publicHeadersPath: "Public"
         )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "AirshipFrameworkProxy",
-            targets: ["AirshipFrameworkProxy"]
+            targets: ["AirshipFrameworkProxy", "AirshipFrameworkProxyBase"]
         )
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "AirshipFrameworkProxy",
-            targets: ["AirshipFrameworkProxy", "AirshipFrameworkProxyBase"]
+            targets: ["AirshipFrameworkProxy", "AirshipFrameworkProxyLoader"]
         )
     ],
     dependencies: [
@@ -19,7 +19,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "AirshipFrameworkProxyBase",
+            name: "AirshipFrameworkProxy",
             dependencies: [
                 .product(name: "AirshipCore", package: "ios-library"),
                 .product(name: "AirshipMessageCenter", package: "ios-library"),
@@ -33,7 +33,7 @@ let package = Package(
             ]
         ),
          .target(
-            name: "AirshipFrameworkProxy",
+            name: "AirshipFrameworkProxyLoader",
             dependencies: [.target(name: "AirshipFrameworkProxyBase")],
             path: "ios/AirshipFrameworkProxyLoader",
             publicHeadersPath: "Public"

--- a/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
+++ b/ios/AirshipFrameworkProxyLoader/UAirshipFrameworkProxyLoader.m
@@ -7,7 +7,7 @@
 #elif __has_include("AirshipFrameworkProxy-Swift.h")
 #import "AirshipFrameworkProxy-Swift.h"
 #else
-@import AirshipFrameworkProxyBase;
+@import AirshipFrameworkProxy;
 #endif
 
 @implementation UAirshipFrameworkProxyLoader


### PR DESCRIPTION
In order to add flutter SPM support the proxy package needs to be updated to expose more classes. Potentially could affect any other platforms that uses SPM version of the proxy, but i don't think there are many of them as the current version exposes close to nothing.

Now we have 2 targets:
old `AirshipFrameworkProxy` -> `AirshipFrameworkProxyLoader`
old `AirshipFrameworkProxyBase` -> `AirshipFrameworkProxy`