### PR TITLE
Swift 6 & remove pending result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Build SDK
         run: |
-          exec pod lib lint AirshipFrameworkProxy.podspec --verbose --platforms=ios
+          exec pod lib lint AirshipFrameworkProxy.podspec --verbose --platforms=ios --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,5 @@ jobs:
       - name: Publish Pods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: exec pod trunk push AirshipFrameworkProxy.podspec
+        run: exec pod trunk push AirshipFrameworkProxy.podspec --allow-warnings
           

--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
    s.module_name             = "AirshipFrameworkProxy"
    s.ios.deployment_target   = "15.0"
    s.requires_arc            = true
-   s.swift_version           = "5.0"
+   s.swift_version           = "6.0"
    s.source_files            = "ios/AirshipFrameworkProxy/**/*.{h,m,swift}"
    s.dependency                'Airship', "19.0.0"
    s.source_files            = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}', 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ActionProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ActionProxy.kt
@@ -1,20 +1,15 @@
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.PendingResult
 import com.urbanairship.actions.ActionResult
 import com.urbanairship.actions.ActionRunner
+import com.urbanairship.actions.runSuspending
 import com.urbanairship.json.JsonValue
 
 public class ActionProxy internal constructor(
     private val actionRunner: () -> ActionRunner
 ) {
-    public fun runAction(name: String, value: JsonValue?): PendingResult<ActionResult> {
-        val pendingResult = PendingResult<ActionResult>()
-        actionRunner().run(name = name, value = value) { _, result ->
-            pendingResult.result = result
-        }
-
-        return pendingResult
+    public suspend fun runAction(name: String, value: JsonValue?): ActionResult {
+        return actionRunner().runSuspending(name = name, value = value)
     }
 }
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ChannelProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ChannelProxy.kt
@@ -1,6 +1,5 @@
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.PendingResult
 import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.android.framework.proxy.SubscriptionListOperation
 import com.urbanairship.android.framework.proxy.TagGroupOperation
@@ -45,8 +44,8 @@ public class ChannelProxy internal constructor(private val channelProvider: () -
         return channelProvider().tags
     }
 
-    public fun getSubscriptionLists(): PendingResult<Set<String>> {
-        return channelProvider().fetchSubscriptionListsPendingResult()
+    public suspend fun getSubscriptionLists(): Set<String> {
+        return channelProvider().fetchSubscriptionLists().getOrThrow()
     }
 
     public fun editSubscriptionLists(operations: JsonValue) {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ContactProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ContactProxy.kt
@@ -1,6 +1,5 @@
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.PendingResult
 import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.android.framework.proxy.ScopedSubscriptionListOperation
 import com.urbanairship.android.framework.proxy.TagGroupOperation
@@ -25,14 +24,10 @@ public class ContactProxy internal constructor(private val contactProvider: () -
         return contactProvider().namedUserId
     }
 
-    public fun getSubscriptionLists(): PendingResult<Map<String, List<String>>> {
-        val pendingResult = PendingResult<Map<String, List<String>>>()
-        contactProvider().fetchSubscriptionListsPendingResult().addResultCallback { result ->
-            pendingResult.result = result?.mapValues { entry ->
-                entry.value.map { it.toString() }
-            }
+    public suspend fun getSubscriptionLists(): Map<String, List<String>> {
+        return contactProvider().fetchSubscriptionLists().getOrThrow().mapValues { entry ->
+            entry.value.map { it.toString() }
         }
-        return pendingResult
     }
 
     public fun notifyRemoteLogin() {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/MessageCenterProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/MessageCenterProxy.kt
@@ -2,7 +2,6 @@ package com.urbanairship.android.framework.proxy.proxies
 
 import android.content.Intent
 import android.net.Uri
-import com.urbanairship.PendingResult
 import com.urbanairship.UAirship
 import com.urbanairship.android.framework.proxy.MessageCenterMessage
 import com.urbanairship.android.framework.proxy.ProxyLogger
@@ -83,16 +82,12 @@ public class MessageCenterProxy internal constructor(
     }
 
 
-    public suspend fun markMessageRead(messageId: String) {
+    public fun markMessageRead(messageId: String) {
         messageCenterProvider().inbox.markMessagesRead(messageId)
     }
 
-    public fun refreshInbox(): PendingResult<Boolean> {
-        val pendingResult = PendingResult<Boolean>()
-        messageCenterProvider().inbox.fetchMessages {
-            pendingResult.result = it
-        }
-        return pendingResult
+    public suspend fun refreshInbox(): Boolean {
+        return messageCenterProvider().inbox.fetchMessages()
     }
 
     public suspend fun getUnreadMessagesCount(): Int {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PreferenceCenterProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PreferenceCenterProxy.kt
@@ -14,8 +14,8 @@ public class PreferenceCenterProxy internal constructor(
         preferenceCenterProvider().open(preferenceCenterId)
     }
 
-    public fun getPreferenceCenterConfig(preferenceCenterId: String): PendingResult<JsonValue> {
-        return preferenceCenterProvider().getJsonConfigPendingResult(preferenceCenterId)
+    public suspend fun getPreferenceCenterConfig(preferenceCenterId: String): JsonValue? {
+        return preferenceCenterProvider().getJsonConfig(preferenceCenterId)
     }
 
     public fun setAutoLaunchPreferenceCenter(preferenceID: String, autoLaunch: Boolean) {

--- a/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
+++ b/ios/AirshipFrameworkProxy.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		6E142EC1296F85CD00F71E23 /* TagGroupOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E142E6D296E3DEB00F71E23 /* TagGroupOperation.swift */; };
 		6E142EC2296F87DA00F71E23 /* AirshipProxyEventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E142E8D296F852300F71E23 /* AirshipProxyEventEmitter.swift */; };
 		6E1EEE772BD2D34C00B45A87 /* AirshipProxyEventEmitterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1EEE762BD2D34B00B45A87 /* AirshipProxyEventEmitterTest.swift */; };
+		6E2DA79E2D4056E9000E9143 /* ProxyPushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2DA79D2D4056E5000E9143 /* ProxyPushPayload.swift */; };
 		6E3A02912CA60B2B00B0C5CF /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */; };
 		6E3A02942CA60B8500B0C5CF /* LiveActivityInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02932CA60B8200B0C5CF /* LiveActivityInfo.swift */; };
 		6E3A02962CA60B9200B0C5CF /* LiveActivityContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3A02952CA60B8F00B0C5CF /* LiveActivityContent.swift */; };
@@ -99,6 +100,7 @@
 		6E142E96296F852300F71E23 /* AirshipProxyEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AirshipProxyEvent.swift; sourceTree = "<group>"; };
 		6E142E97296F852300F71E23 /* AirshipPreferenceCenterProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AirshipPreferenceCenterProxy.swift; sourceTree = "<group>"; };
 		6E1EEE762BD2D34B00B45A87 /* AirshipProxyEventEmitterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipProxyEventEmitterTest.swift; sourceTree = "<group>"; };
+		6E2DA79D2D4056E5000E9143 /* ProxyPushPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyPushPayload.swift; sourceTree = "<group>"; };
 		6E3A02902CA60B2600B0C5CF /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		6E3A02932CA60B8200B0C5CF /* LiveActivityInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityInfo.swift; sourceTree = "<group>"; };
 		6E3A02952CA60B8F00B0C5CF /* LiveActivityContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityContent.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 		6E142E4E296E3A8800F71E23 /* AirshipFrameworkProxy */ = {
 			isa = PBXGroup;
 			children = (
+				6E2DA79D2D4056E5000E9143 /* ProxyPushPayload.swift */,
 				6EC9A28A2CC963A800FFF4C5 /* AirshipPluginForwardListeners.swift */,
 				6ED117B32CA75D1B00C41C56 /* Loader */,
 				6E3A028F2CA60B1C00B0C5CF /* LiveActivity */,
@@ -481,6 +484,7 @@
 				6E142EBC296F85CD00F71E23 /* AttributeOperation.swift in Sources */,
 				6E142EBD296F85CD00F71E23 /* ProxyConfig.swift in Sources */,
 				6EFB83DA2979BE7F0008BEB5 /* ScopedSubscriptionListOperation.swift in Sources */,
+				6E2DA79E2D4056E9000E9143 /* ProxyPushPayload.swift in Sources */,
 				6E142EBE296F85CD00F71E23 /* ProxyStore.swift in Sources */,
 				6EC755402A4A494C00851ABB /* NotificationStatus.swift in Sources */,
 				6EC9A28B2CC963B100FFF4C5 /* AirshipPluginForwardListeners.swift in Sources */,
@@ -685,7 +689,20 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_UPCOMING_FEATURE_CONCISE_MAGIC_FILE = YES;
+				SWIFT_UPCOMING_FEATURE_DEPRECATE_APPLICATION_MAIN = YES;
+				SWIFT_UPCOMING_FEATURE_DISABLE_OUTWARD_ACTOR_ISOLATION = YES;
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_UPCOMING_FEATURE_FORWARD_TRAILING_CLOSURES = YES;
+				SWIFT_UPCOMING_FEATURE_GLOBAL_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_IMPLICIT_OPEN_EXISTENTIALS = YES;
+				SWIFT_UPCOMING_FEATURE_IMPORT_OBJC_FORWARD_DECLS = YES;
+				SWIFT_UPCOMING_FEATURE_INFER_SENDABLE_FROM_CAPTURES = YES;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
+				SWIFT_UPCOMING_FEATURE_ISOLATED_DEFAULT_VALUES = YES;
+				SWIFT_UPCOMING_FEATURE_REGION_BASED_ISOLATION = YES;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -715,7 +732,20 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_UPCOMING_FEATURE_CONCISE_MAGIC_FILE = YES;
+				SWIFT_UPCOMING_FEATURE_DEPRECATE_APPLICATION_MAIN = YES;
+				SWIFT_UPCOMING_FEATURE_DISABLE_OUTWARD_ACTOR_ISOLATION = YES;
+				SWIFT_UPCOMING_FEATURE_EXISTENTIAL_ANY = YES;
+				SWIFT_UPCOMING_FEATURE_FORWARD_TRAILING_CLOSURES = YES;
+				SWIFT_UPCOMING_FEATURE_GLOBAL_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_IMPLICIT_OPEN_EXISTENTIALS = YES;
+				SWIFT_UPCOMING_FEATURE_IMPORT_OBJC_FORWARD_DECLS = YES;
+				SWIFT_UPCOMING_FEATURE_INFER_SENDABLE_FROM_CAPTURES = YES;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
+				SWIFT_UPCOMING_FEATURE_ISOLATED_DEFAULT_VALUES = YES;
+				SWIFT_UPCOMING_FEATURE_REGION_BASED_ISOLATION = YES;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ios/AirshipFrameworkProxy/AirshipFrameworkProxy.h
+++ b/ios/AirshipFrameworkProxy/AirshipFrameworkProxy.h
@@ -2,7 +2,6 @@
 //  AirshipFrameworkProxy.h
 //  AirshipFrameworkProxy
 //
-//  Created by Ryan Lepinski on 1/10/23.
 //
 
 #import <Foundation/Foundation.h>

--- a/ios/AirshipFrameworkProxy/AirshipPluginForwardListeners.swift
+++ b/ios/AirshipFrameworkProxy/AirshipPluginForwardListeners.swift
@@ -3,27 +3,27 @@
 import Foundation
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 /// Plugin forward delegates
 @MainActor
-public class AirshipPluginForwardDelegates {
+public final class AirshipPluginForwardDelegates {
     /// Shared instance
     public static let shared: AirshipPluginForwardDelegates = AirshipPluginForwardDelegates()
 
     /// Deep link delegate
-    public var deepLinkDelegate: AirshipPluginDeepLinkDelegate?
+    public var deepLinkDelegate: (any AirshipPluginDeepLinkDelegate)?
 
     /// Push notification delegate.
     /// Note:  Implementing `extendPresentationOptions(_:notification:completionHandler:)`
     /// will break handling of request options per notification in plugins that support that feature.
-    public var pushNotificationDelegate: PushNotificationDelegate?
+    public var pushNotificationDelegate: (any PushNotificationDelegate)?
 
     /// Registration delegate
-    public var registrationDelegate: RegistrationDelegate?
+    public var registrationDelegate: (any RegistrationDelegate)?
 
     private init() {}
 }

--- a/ios/AirshipFrameworkProxy/AirshipProxyEventEmitter.swift
+++ b/ios/AirshipFrameworkProxy/AirshipProxyEventEmitter.swift
@@ -1,20 +1,20 @@
 import Foundation
-import Combine
+@preconcurrency public import Combine
 
 public actor AirshipProxyEventEmitter {
-    private let updateContinuation: AsyncStream<AirshipProxyEvent>.Continuation
-    public let pendingEventAdded: AsyncStream<AirshipProxyEvent>
+    private let updateContinuation: AsyncStream<any AirshipProxyEvent>.Continuation
+    public let pendingEventAdded: AsyncStream<any AirshipProxyEvent>
     public static let shared = AirshipProxyEventEmitter()
-    private nonisolated let eventSubject = PassthroughSubject<AirshipProxyEvent, Never>()
+    private nonisolated let eventSubject = PassthroughSubject<any AirshipProxyEvent, Never>()
 
-    private var pendingEvents: [AirshipProxyEvent] = []
+    private var pendingEvents: [any AirshipProxyEvent] = []
 
-    public nonisolated var pendingEventPublisher: AnyPublisher<AirshipProxyEvent, Never> {
+    public nonisolated var pendingEventPublisher: AnyPublisher<any AirshipProxyEvent, Never> {
         eventSubject.eraseToAnyPublisher()
     }
 
     init() {
-        var escapee: AsyncStream<AirshipProxyEvent>.Continuation!
+        var escapee: AsyncStream<any AirshipProxyEvent>.Continuation!
         self.pendingEventAdded = AsyncStream { continuation in
             escapee = continuation
         }
@@ -33,9 +33,9 @@ public actor AirshipProxyEventEmitter {
 
     public func takePendingEvents(
         type: AirshipProxyEventType
-    ) -> [AirshipProxyEvent] {
+    ) -> [any AirshipProxyEvent] {
 
-        var result: [AirshipProxyEvent] = []
+        var result: [any AirshipProxyEvent] = []
         
         pendingEvents.removeAll(where: { event in
             if event.type == type {
@@ -51,7 +51,7 @@ public actor AirshipProxyEventEmitter {
 
     public func processPendingEvents(
         type: AirshipProxyEventType?,
-        handler: (AirshipProxyEvent) -> Bool
+        handler: (any AirshipProxyEvent) -> Bool
     ) {
         let types: Set<AirshipProxyEventType> = if let type = type {
             Set([type])
@@ -68,7 +68,7 @@ public actor AirshipProxyEventEmitter {
         })
     }
 
-    func addEvent(_ event: AirshipProxyEvent, replacePending: Bool = false) {
+    func addEvent(_ event: any AirshipProxyEvent, replacePending: Bool = false) {
         if replacePending {
             self.pendingEvents.removeAll { event.type == $0.type }
         }

--- a/ios/AirshipFrameworkProxy/AttributeOperation.swift
+++ b/ios/AirshipFrameworkProxy/AttributeOperation.swift
@@ -7,13 +7,13 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public struct AttributeOperation: Decodable, Equatable {
+public struct AttributeOperation: Decodable, Equatable, Sendable {
     enum Action: String, Decodable {
         case setAttribute = "set"
         case removeAttribute = "remove"
     }
 
-    enum ValueType: String, Decodable {
+    enum ValueType: String, Decodable, Sendable {
         case string
         case number
         case date
@@ -31,7 +31,7 @@ public struct AttributeOperation: Decodable, Equatable {
         case valueType = "type"
     }
 
-    func apply(editor: AttributeOperationEditor) throws {
+    func apply(editor: any AttributeOperationEditor) throws {
         switch(action) {
         case .removeAttribute:
             editor.remove(attribute)

--- a/ios/AirshipFrameworkProxy/DefaultMessageCenterUI.swift
+++ b/ios/AirshipFrameworkProxy/DefaultMessageCenterUI.swift
@@ -12,7 +12,7 @@ import AirshipMessageCenter
 @MainActor
 public class DefaultMessageCenterUI {
     static let shared: DefaultMessageCenterUI = DefaultMessageCenterUI()
-    private var currentDisplay: AirshipMainActorCancellable?
+    private var currentDisplay: (any AirshipMainActorCancellable)?
     private var controller: MessageCenterController = MessageCenterController()
 
     func dismiss() {
@@ -59,7 +59,7 @@ public class DefaultMessageCenterUI {
     private func open(
         scene: UIWindowScene,
         theme: MessageCenterTheme?
-    ) -> AirshipMainActorCancellable {
+    ) -> any AirshipMainActorCancellable {
         var window: UIWindow? = UIWindow(windowScene: scene)
 
         let cancellable = AirshipMainActorCancellableBlock {
@@ -88,7 +88,7 @@ public class DefaultMessageCenterUI {
         scene: UIWindowScene,
         messageID: String,
         theme: MessageCenterTheme?
-    ) -> AirshipMainActorCancellable {
+    ) -> any AirshipMainActorCancellable {
         var window: UIWindow? = UIWindow(windowScene: scene)
 
         let cancellable = AirshipMainActorCancellableBlock {

--- a/ios/AirshipFrameworkProxy/EmbeddedEventEmitter.swift
+++ b/ios/AirshipFrameworkProxy/EmbeddedEventEmitter.swift
@@ -1,7 +1,7 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 #if canImport(AirshipKit)
 import AirshipKit
@@ -15,7 +15,7 @@ public actor EmbeddedEventEmitter {
         proxyEventEmitter: AirshipProxyEventEmitter.shared
     )
 
-    private var lastEvent: AirshipProxyEvent?
+    private var lastEvent: (any AirshipProxyEvent)?
     private var task: Task<Void, Never>?
 
 

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityContent.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityContent.swift
@@ -1,9 +1,9 @@
 /* Copyright Airship and Contributors */
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 public struct LiveActivityContent: Sendable, Equatable, Codable, Hashable {

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityInfo.swift
@@ -1,9 +1,9 @@
 /* Copyright Airship and Contributors */
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 import ActivityKit

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -1,6 +1,6 @@
 /* Copyright Airship and Contributors */
 
-import ActivityKit
+public import ActivityKit
 
 #if canImport(AirshipKit)
 import AirshipKit
@@ -13,15 +13,15 @@ public actor LiveActivityManager: Sendable {
 
     public static let shared = LiveActivityManager()
 
-    fileprivate struct Entry {
-        let list: () throws -> [LiveActivityInfo]
-        let start: (LiveActivityRequest.Start) async throws -> LiveActivityInfo
-        let update: (LiveActivityRequest.Update) async throws -> Bool
-        let end: (LiveActivityRequest.End) async throws -> Bool
-        let track: (String) -> Void
+    fileprivate struct Entry: Sendable {
+        var list: @Sendable () throws -> [LiveActivityInfo]
+        var start: @Sendable (LiveActivityRequest.Start) async throws -> LiveActivityInfo
+        var update: @Sendable (LiveActivityRequest.Update) async throws -> Bool
+        var end: @Sendable (LiveActivityRequest.End) async throws -> Bool
+        var track: @Sendable (String) -> Void
 
-        let pushToStartUpdates: ((@escaping @Sendable () async -> Void)) -> Void
-        let activityUpdates: (String, (@escaping @Sendable (LiveActivityInfo?) async -> Void)) -> Void
+        var pushToStartUpdates: @Sendable ((@escaping @Sendable () async -> Void)) -> Void
+        var activityUpdates: @Sendable (String, (@escaping @Sendable (LiveActivityInfo?) async -> Void)) -> Void
     }
 
     private var entries: [String: Entry] = [:]
@@ -33,9 +33,9 @@ public actor LiveActivityManager: Sendable {
 
     public actor Configurator {
         fileprivate var entries: [String: Entry] = [:]
-        private var restorer: LiveActivityRestorer
+        private var restorer: any LiveActivityRestorer
 
-        init(restorer: LiveActivityRestorer) {
+        init(restorer: any LiveActivityRestorer) {
             self.restorer = restorer
         }
 
@@ -290,7 +290,7 @@ extension LiveActivityManager.Entry {
             return try LiveActivityInfo(activity: activity, attributesType: attributesType)
         }
 
-        self.track = { activityID in
+        self.track = { @Sendable activityID in
             Self.track(
                 type,
                 activityID:activityID,

--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityRequest.swift
@@ -1,9 +1,9 @@
 /* Copyright Airship and Contributors */
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 public struct LiveActivityRequest: Sendable, Equatable {

--- a/ios/AirshipFrameworkProxy/Loader/AirshipFrameworkProxyLoader.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipFrameworkProxyLoader.swift
@@ -1,6 +1,6 @@
 /* Copyright Airship and Contributors */
 
-import UIKit
+public import UIKit
 
 #if canImport(AirshipKit)
 import AirshipKit
@@ -11,8 +11,8 @@ import AirshipCore
 @objc
 @MainActor
 public class AirshipFrameworkProxyLoader: NSObject {
-    private static let pluginLoader: AirshipPluginLoaderProtocol.Type? = {
-        NSClassFromString("AirshipPluginLoader") as? AirshipPluginLoaderProtocol.Type
+    private static let pluginLoader: (any AirshipPluginLoaderProtocol.Type)? = {
+        NSClassFromString("AirshipPluginLoader") as? any AirshipPluginLoaderProtocol.Type
     }()
 
     @objc

--- a/ios/AirshipFrameworkProxy/Loader/AirshipPluginExtenderProtocol.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipPluginExtenderProtocol.swift
@@ -3,9 +3,9 @@
 import Foundation
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 public protocol AirshipPluginExtenderProtocol: NSObject {
@@ -17,6 +17,5 @@ public protocol AirshipPluginExtenderProtocol: NSObject {
 }
 
 public extension AirshipPluginExtenderProtocol {
-    static func extendConfig(config: AirshipConfig) {
-    }
+    static func extendConfig(config: AirshipConfig) {}
 }

--- a/ios/AirshipFrameworkProxy/Loader/AirshipPluginLoaderProtocol.swift
+++ b/ios/AirshipFrameworkProxy/Loader/AirshipPluginLoaderProtocol.swift
@@ -1,6 +1,6 @@
 /* Copyright Airship and Contributors */
 
-import UIKit
+public import UIKit
 
 public protocol AirshipPluginLoaderProtocol: NSObject {
     @MainActor

--- a/ios/AirshipFrameworkProxy/NotificationStatus.swift
+++ b/ios/AirshipFrameworkProxy/NotificationStatus.swift
@@ -36,23 +36,5 @@ public struct NotificationStatus: Sendable, Equatable, Codable {
         case isOptedIn
         case notificationPermissionStatus
     }
-
-    var toMap: [String: Any] {
-        var map: [String: Any] = [
-            "isUserNotificationsEnabled": self.isUserNotificationsEnabled,
-            "areNotificationsAllowed": self.areNotificationsAllowed,
-            "isPushPrivacyFeatureEnabled": self.isPushPrivacyFeatureEnabled,
-            "isPushTokenRegistered": self.isPushTokenRegistered,
-            "isOptedIn": self.isOptedIn,
-            "isUserOptedIn": self.isUserOptedIn
-        ]
-
-        if let notificationPermissionStatus {
-            map["notificationPermissionStatus"] = notificationPermissionStatus
-        }
-
-        return map
-    }
-
 }
 

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipActionProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipActionProxy.swift
@@ -3,25 +3,25 @@
 import Foundation
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 public enum AirshipActionProxyError: Error {
     case actionNotFound
-    case actionError(Error?)
+    case actionError((any Error)?)
     case actionRejectedArguments
 }
 
-public class AirshipActionProxy: NSObject {
+public final class AirshipActionProxy: Sendable {
 
-    private let actionRunnerProvider: () throws -> AirshipActionRunnerProtocol
-    private var actionRunner: AirshipActionRunnerProtocol {
+    private let actionRunnerProvider: @Sendable () throws -> any AirshipActionRunnerProtocol
+    private var actionRunner: any AirshipActionRunnerProtocol {
         get throws { try actionRunnerProvider() }
     }
 
-    init(actionRunnerProvider: @escaping () throws -> AirshipActionRunnerProtocol) {
+    init(actionRunnerProvider: @Sendable @escaping () throws -> any AirshipActionRunnerProtocol) {
         self.actionRunnerProvider = actionRunnerProvider
     }
 
@@ -47,12 +47,12 @@ public class AirshipActionProxy: NSObject {
     }
 }
 
-protocol AirshipActionRunnerProtocol: AnyObject {
+protocol AirshipActionRunnerProtocol: AnyObject, Sendable {
     func runAction(_ name: String, value: AirshipJSON?) async -> ActionResult
 }
 
 
-class AirshipActionRunner: AirshipActionRunnerProtocol {
+final class AirshipActionRunner: AirshipActionRunnerProtocol {
     func runAction(_ name: String, value: AirshipJSON?) async -> ActionResult {
         return await ActionRunner.run(
             actionName: name,

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipAnalyticsProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipAnalyticsProxy.swift
@@ -8,14 +8,14 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public class AirshipAnalyticsProxy {
+public final class AirshipAnalyticsProxy: Sendable {
 
-    private let analyticsProvider: () throws -> AirshipAnalyticsProtocol
-    private var analytics: AirshipAnalyticsProtocol {
+    private let analyticsProvider: @Sendable () throws -> any AirshipAnalyticsProtocol
+    private var analytics: any AirshipAnalyticsProtocol {
         get throws { try analyticsProvider() }
     }
 
-    init(analyticsProvider: @escaping () throws -> AirshipAnalyticsProtocol) {
+    init(analyticsProvider: @Sendable  @escaping () throws -> any AirshipAnalyticsProtocol) {
         self.analyticsProvider = analyticsProvider
     }
 

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipFeatureFlagManagerProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipFeatureFlagManagerProxy.swift
@@ -64,7 +64,7 @@ public final class AirshipFeatureFlagManagerProxy: Sendable {
 
 // We encode `isEligible` as snake case breaking the APIs for react. This
 // wraps it so we can return camelCase like all other APIs.
-public struct FeatureFlagProxy: Codable {
+public struct FeatureFlagProxy: Codable, Sendable {
     let isEligible: Bool
     let exists: Bool
     let variables: AirshipJSON?

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipInAppProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipInAppProxy.swift
@@ -9,14 +9,14 @@ import AirshipCore
 import AirshipAutomation
 #endif
 
-public class AirshipInAppProxy {
+public final class AirshipInAppProxy: Sendable {
 
-    private let inAppProvider: () throws -> AirshipInAppProtocol
-    private var inApp: AirshipInAppProtocol {
+    private let inAppProvider: @Sendable () throws -> InAppAutomation
+    private var inApp: InAppAutomation {
         get throws { try inAppProvider() }
     }
 
-    init(inAppProvider: @escaping () throws -> any AirshipInAppProtocol) {
+    init(inAppProvider: @Sendable @escaping () throws -> InAppAutomation) {
         self.inAppProvider = inAppProvider
     }
 
@@ -33,37 +33,18 @@ public class AirshipInAppProxy {
 
     @MainActor
     public func getDisplayInterval() throws -> Int {
-        return Int(try self.inApp.displayInterval * 1000)
+        return Int(try self.inApp.inAppMessaging.displayInterval * 1000)
     }
 
     @MainActor
-    public func setDisplayInterval(_ displayInterval: Int) throws {
-        let seconds = Double(displayInterval)/1000.0
-        try self.inApp.displayInterval = seconds
+    public func setDisplayInterval(milliseconds: Int) throws {
+        let seconds = Double(milliseconds)/1000.0
+        try self.inApp.inAppMessaging.displayInterval = seconds
     }
 
     public func resendLastEmbeddedEvent() {
         Task {
             await EmbeddedEventEmitter.shared.resendLastEvent()
-        }
-    }
-}
-
-protocol AirshipInAppProtocol: AnyObject {
-    @MainActor
-    var displayInterval: TimeInterval { get set }
-    @MainActor
-    var isPaused: Bool { get set }
-}
-
-extension InAppAutomation : AirshipInAppProtocol {
-    @MainActor
-    var displayInterval: TimeInterval {
-        get {
-            self.inAppMessaging.displayInterval
-        }
-        set {
-            self.inAppMessaging.displayInterval = newValue
         }
     }
 }

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipLocaleProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipLocaleProxy.swift
@@ -8,14 +8,14 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public class AirshipLocaleProxy {
+public final class AirshipLocaleProxy: Sendable {
 
-    private let localeProvider: () throws -> AirshipLocaleManagerProtocol
-    private var locale: AirshipLocaleManagerProtocol {
+    private let localeProvider: @Sendable () throws -> any AirshipLocaleManagerProtocol
+    private var locale: any AirshipLocaleManagerProtocol {
         get throws { try localeProvider() }
     }
 
-    init(localeProvider: @escaping () throws -> any AirshipLocaleManagerProtocol) {
+    init(localeProvider: @Sendable @escaping () throws -> any AirshipLocaleManagerProtocol) {
         self.localeProvider = localeProvider
     }
 
@@ -30,8 +30,10 @@ public class AirshipLocaleProxy {
 
     }
 
-    public func getCurrentLocale() throws -> String {
-        return try self.locale.currentLocale.identifier
+    public var currentLocale: String {
+        get throws {
+            return try self.locale.currentLocale.identifier
+        }
     }
 
     public func clearLocale() throws {

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipPreferenceCenterProxy.swift
@@ -9,18 +9,18 @@ import AirshipCore
 import AirshipPreferenceCenter
 #endif
 
-public class AirshipPreferenceCenterProxy {
+public final class AirshipPreferenceCenterProxy: Sendable {
 
     private let proxyStore: ProxyStore
 
-    private let preferenceCenterProvider: () throws -> PreferenceCenter
+    private let preferenceCenterProvider: @Sendable () throws -> PreferenceCenter
     private var preferenceCenter: PreferenceCenter {
         get throws { try preferenceCenterProvider() }
     }
 
     init(
         proxyStore: ProxyStore,
-        preferenceCenterProvider: @escaping () throws -> PreferenceCenter
+        preferenceCenterProvider: @Sendable @escaping () throws -> PreferenceCenter
     ) {
         self.proxyStore = proxyStore
         self.preferenceCenterProvider = preferenceCenterProvider
@@ -31,6 +31,7 @@ public class AirshipPreferenceCenterProxy {
         try self.preferenceCenter.open(preferenceCenterID)
     }
 
+    @MainActor
     public func setAutoLaunchPreferenceCenter(
         _ autoLaunch: Bool,
         preferenceCenterID: String

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipPrivacyManagerProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipPrivacyManagerProxy.swift
@@ -3,20 +3,20 @@
 import Foundation
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
-public class AirshipPrivacyManagerProxy {
+public final class AirshipPrivacyManagerProxy: Sendable {
 
-    private let privacyManagerProvider: () throws -> AirshipPrivacyManagerProtocol
-    private var privacyManager: AirshipPrivacyManagerProtocol {
+    private let privacyManagerProvider: @Sendable () throws -> AirshipPrivacyManager
+    private var privacyManager: AirshipPrivacyManager {
         get throws { try privacyManagerProvider() }
     }
 
     init(
-        privacyManagerProvider: @escaping () throws -> AirshipPrivacyManagerProtocol
+        privacyManagerProvider: @Sendable @escaping () throws -> AirshipPrivacyManager
     ) {
         self.privacyManagerProvider = privacyManagerProvider
     }
@@ -95,12 +95,3 @@ public class AirshipPrivacyManagerProxy {
         )
     }
 }
-
-protocol AirshipPrivacyManagerProtocol: AnyObject {
-    var enabledFeatures: AirshipFeature { get set}
-    func enableFeatures(_ features: AirshipFeature)
-    func disableFeatures(_ features: AirshipFeature)
-    func isEnabled(_ feature: AirshipFeature) -> Bool
-}
-
-extension AirshipPrivacyManager: AirshipPrivacyManagerProtocol {}

--- a/ios/AirshipFrameworkProxy/Proxies/AirshipProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipProxy.swift
@@ -4,9 +4,9 @@ import Foundation
 import Combine
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 import AirshipAutomation
 import AirshipMessageCenter
 import AirshipFeatureFlags
@@ -24,17 +24,22 @@ public protocol AirshipProxyDelegate {
     func onAirshipReady()
 }
 
-public class AirshipProxy {
+public final class AirshipProxy: Sendable {
 
-    private static let extender: AirshipPluginExtenderProtocol.Type? = {
-        NSClassFromString("AirshipPluginExtender") as? AirshipPluginExtenderProtocol.Type
+    private static let extender: (any AirshipPluginExtenderProtocol.Type)? = {
+        NSClassFromString("AirshipPluginExtender") as? any AirshipPluginExtenderProtocol.Type
     }()
 
-    public var delegate: AirshipProxyDelegate?
+    @MainActor
+    public var delegate: (any AirshipProxyDelegate)?
+    @MainActor
     private var migrateCalled: Bool = false
+    @MainActor
     private var subscriptions: Set<AnyCancellable> = Set()
 
     private let proxyStore: ProxyStore
+
+    @MainActor
     private var airshipDelegate: AirshipDelegate?
 
     public let locale: AirshipLocaleProxy

--- a/ios/AirshipFrameworkProxy/ProxyConfig.swift
+++ b/ios/AirshipFrameworkProxy/ProxyConfig.swift
@@ -3,9 +3,9 @@
 import Foundation
 
 #if canImport(AirshipKit)
-import AirshipKit
+public import AirshipKit
 #elseif canImport(AirshipCore)
-import AirshipCore
+public import AirshipCore
 #endif
 
 

--- a/ios/AirshipFrameworkProxy/ProxyPushPayload.swift
+++ b/ios/AirshipFrameworkProxy/ProxyPushPayload.swift
@@ -1,0 +1,78 @@
+/* Copyright Airship and Contributors */
+
+import Foundation
+
+#if canImport(AirshipKit)
+public import AirshipKit
+#elseif canImport(AirshipCore)
+public import AirshipCore
+#endif
+
+public struct ProxyPushPayload: Sendable, Codable {
+    public let notificationID: String?
+    public let alert: String?
+    public let title: String?
+    public let extras: AirshipJSON
+
+    enum CodingKeys: String, CodingKey {
+        case alert
+        case title
+        case extras
+        case notificationID = "notificationId"
+    }
+
+    init(request: UNNotificationRequest) throws {
+        try self.init(
+            userInfo: request.content.userInfo,
+            notificationID: request.identifier
+        )
+    }
+
+    init(notification: UNNotification) throws {
+        try self.init(
+            request: notification.request
+        )
+    }
+
+    init(
+        userInfo: [AnyHashable: Any],
+        notificationID: String? = nil
+    ) throws {
+
+        self.notificationID = notificationID
+        self.alert = Self.parseAlert(userInfo)
+        self.title = Self.parseTitle(userInfo)
+
+        var extras = userInfo
+        extras["_"] = nil
+        extras["aps"] = nil
+        self.extras = try AirshipJSON.wrap(extras)
+    }
+
+
+    private static func parseAlert(_ userInfo: [AnyHashable: Any]) -> String? {
+        if let aps = userInfo["aps"] as? [String : Any] {
+            if let alert = aps["alert"] as? [String : Any] {
+                if let body = alert["body"] as? String {
+                    return body
+                }
+            } else if let alert = aps["alert"] as? String {
+                return alert
+            }
+        }
+
+        return nil
+    }
+
+    private static func parseTitle(_ userInfo: [AnyHashable: Any]) -> String? {
+        if let aps = userInfo["aps"] as? [String : Any] {
+            if let alert = aps["alert"] as? [String : Any] {
+                if let title = alert["title"] as? String {
+                    return title
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/ios/AirshipFrameworkProxy/ProxyStore.swift
+++ b/ios/AirshipFrameworkProxy/ProxyStore.swift
@@ -1,7 +1,7 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
-import UserNotifications
+public import UserNotifications
 
 #if canImport(AirshipKit)
 import AirshipKit
@@ -9,23 +9,23 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public class ProxyStore {
+public final class ProxyStore: Sendable {
 
     static let shared: ProxyStore = ProxyStore()
 
-    private let defaults: UserDefaults = UserDefaults(
-        suiteName: "airship-framework-proxy"
-    )!
-
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
+    private var defaults: UserDefaults  {
+        UserDefaults(suiteName: "airship-framework-proxy")!
+    }
 
     private let configKey = "config"
     private let foregroundPresentationOptionsKey = "foregroundPresentationOptions"
     private let autoDisplayMessageCenterKey = "autoDisplayMessageCenter"
     private let lastNotificationStatusKey = "lastNotificationStatus"
 
+    @MainActor
     public var defaultAutoDisplayMessageCenter: Bool = true
+
+    @MainActor
     public var defaultPresentationOptions: UNNotificationPresentationOptions = []
 
 
@@ -38,6 +38,7 @@ public class ProxyStore {
         }
     }
 
+    @MainActor
     public var foregroundPresentationOptions: UNNotificationPresentationOptions {
         get {
             guard 
@@ -58,6 +59,7 @@ public class ProxyStore {
         }
     }
 
+    @MainActor
     public var autoDisplayMessageCenter: Bool {
         get {
             return readValue(autoDisplayMessageCenterKey) ?? defaultAutoDisplayMessageCenter
@@ -116,7 +118,7 @@ public class ProxyStore {
         }
 
         do {
-            return try decoder.decode(T.self, from: data)
+            return try JSONDecoder().decode(T.self, from: data)
         } catch {
             AirshipLogger.error("Failed to decode value for key \(key): \(error)")
             return nil
@@ -138,7 +140,7 @@ public class ProxyStore {
         }
 
         do {
-            let data = try encoder.encode(codable)
+            let data = try JSONEncoder().encode(codable)
             writeValue(data, forKey: key)
         } catch {
             AirshipLogger.error("Failed to write codable for key \(key): \(error)")

--- a/ios/AirshipFrameworkProxy/PushUtils.swift
+++ b/ios/AirshipFrameworkProxy/PushUtils.swift
@@ -9,35 +9,6 @@ import AirshipCore
 #endif
 
 struct PushUtils {
-    static func contentPayload(
-        _ userInfo: [AnyHashable: Any],
-        notificationID: String? = nil
-    ) -> [String : Any] {
-
-        var pushPayload: [String: Any] = [:]
-        if let aps = userInfo["aps"] as? [String : Any] {
-            if let alert = aps["alert"] as? [String : Any] {
-                if let body = alert["body"] {
-                    pushPayload["alert"] = body
-                }
-                if let title = alert["title"] {
-                    pushPayload["title"] = title
-                }
-            } else if let alert = aps["alert"] as? String {
-                pushPayload["alert"] = alert
-            }
-        }
-
-        var extras = userInfo
-        extras["_"] = nil
-        extras["aps"] = nil
-
-        pushPayload["extras"] = extras
-        pushPayload["notificationId"] = notificationID
-
-        return pushPayload
-    }
-
     @MainActor
     static func findAction(_ notificationResponse: UNNotificationResponse) -> UNNotificationAction? {
         return Airship.push.combinedCategories.first(where: { (category) -> Bool in

--- a/ios/AirshipFrameworkProxy/ScopedSubscriptionListOperation.swift
+++ b/ios/AirshipFrameworkProxy/ScopedSubscriptionListOperation.swift
@@ -8,8 +8,8 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public struct ScopedSubscriptionListOperation: Decodable, Equatable {
-    enum Action: String, Codable {
+public struct ScopedSubscriptionListOperation: Decodable, Equatable, Sendable {
+    enum Action: String, Codable, Sendable {
         case subscribe
         case unsubscribe
     }
@@ -24,14 +24,13 @@ public struct ScopedSubscriptionListOperation: Decodable, Equatable {
         self.scope = scope
     }
 
-
     private enum CodingKeys: String, CodingKey {
         case action = "action"
         case listID = "listId"
         case scope = "scope"
     }
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.action = try container.decode(ScopedSubscriptionListOperation.Action.self, forKey: .action)
         self.listID = try container.decode(String.self, forKey: .listID)

--- a/ios/AirshipFrameworkProxy/SubscriptionListOperation.swift
+++ b/ios/AirshipFrameworkProxy/SubscriptionListOperation.swift
@@ -8,8 +8,8 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public struct SubscriptionListOperation: Decodable {
-    enum Action: String, Codable {
+public struct SubscriptionListOperation: Decodable, Sendable {
+    enum Action: String, Codable, Sendable {
         case subscribe
         case unsubscribe
     }

--- a/ios/AirshipFrameworkProxy/TagOperation.swift
+++ b/ios/AirshipFrameworkProxy/TagOperation.swift
@@ -8,8 +8,8 @@ import AirshipKit
 import AirshipCore
 #endif
 
-public struct TagOperation: Decodable, Equatable {
-    enum Action: String, Codable {
+public struct TagOperation: Decodable, Equatable, Sendable {
+    enum Action: String, Codable, Sendable {
         case removeTags = "remove"
         case addTags = "add"
     }
@@ -22,7 +22,7 @@ public struct TagOperation: Decodable, Equatable {
         case tags = "tags"
     }
 
-    func apply(editor: TagOperationEditor) {
+    func apply(editor: any TagOperationEditor) {
         switch(action) {
         case .removeTags:
             editor.remove(tags)

--- a/ios/AirshipFrameworkProxyTests/AirshipProxyEventEmitterTest.swift
+++ b/ios/AirshipFrameworkProxyTests/AirshipProxyEventEmitterTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AirshipKit
 @testable import AirshipFrameworkProxy
 
 final class AirshipProxyEventEmitterTest: XCTestCase {
@@ -28,7 +29,9 @@ final class AirshipProxyEventEmitterTest: XCTestCase {
 }
 
 fileprivate struct TestEvent: AirshipProxyEvent {
+    typealias T = AirshipJSON
+
     var type: AirshipProxyEventType
-    var body: [String : Any] = [:]
+    var body: AirshipJSON  = .bool(true)
 }
 

--- a/ios/AirshipFrameworkProxyTests/ProxyConfigTests.swift
+++ b/ios/AirshipFrameworkProxyTests/ProxyConfigTests.swift
@@ -77,7 +77,7 @@ final class ProxyConfigTests: XCTestCase {
             from: fullConfig.data(using: .utf8)!
         )
 
-        let airshipConfig = AirshipConfig()
+        var airshipConfig = AirshipConfig()
         airshipConfig.applyProxyConfig(proxyConfig: proxyConfig)
 
         XCTAssertEqual(

--- a/ios/AirshipFrameworkProxyTests/TagOperationTest.swift
+++ b/ios/AirshipFrameworkProxyTests/TagOperationTest.swift
@@ -75,14 +75,14 @@ class TagOperationTest: XCTestCase {
             action: TagOperation.Action.addTags,
             tags: ["oneTag", "anotherTag", "andALastOne"]
         )
-        try operation.apply(editor: editor)
+        operation.apply(editor: editor)
         XCTAssertEqual(editor.currentTags, ["oneTag", "anotherTag", "andALastOne"])
         
         let nextOperation = TagOperation(
             action: TagOperation.Action.removeTags,
             tags: ["anotherTag", "andALastOne"]
         )
-        try nextOperation.apply(editor: editor)
+        nextOperation.apply(editor: editor)
         XCTAssertEqual(editor.currentTags, ["oneTag"])
     }
 


### PR DESCRIPTION
Migrate proxy to swift 6 for iOS and removes pending result on Android. Breaking API changes when we update the proxy per framework. 