### PR TITLE
[MOBILE-4912] handle unknown default case

### DIFF
--- a/ios/AirshipFrameworkProxy/Proxies/AirshipActionProxy.swift
+++ b/ios/AirshipFrameworkProxy/Proxies/AirshipActionProxy.swift
@@ -43,6 +43,10 @@ public final class AirshipActionProxy: Sendable {
             throw AirshipActionProxyError.actionRejectedArguments
         case .error(let actionError):
             throw AirshipActionProxyError.actionError(actionError)
+        @unknown default:
+            throw AirshipErrors.error(
+                "Unknown ActionResult \(result)"
+            )
         }
     }
 }


### PR DESCRIPTION
This is supposed to be a Swift 5 warning but it's treated as an error in expo projects and so the build crashes.
I tried to fix it without having to update the proxy and the react framework with no success.