### PR TITLE
Release 14.10.2

### DIFF
--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-   s.version                 = "14.10.1"
+   s.version                 = "14.10.2"
    s.name                    = "AirshipFrameworkProxy"
    s.summary                 = "Airship iOS mobile framework proxy"
    s.documentation_url       = "https://docs.airship.com/platform/mobile"
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
    s.requires_arc            = true
    s.swift_version           = "6.0"
    s.source_files            = "ios/AirshipFrameworkProxy/**/*.{h,m,swift}"
-   s.dependency                'Airship', "19.11.2"
+   s.dependency                'Airship', "19.11.6"
    s.source_files            = 'ios/AirshipFrameworkProxyLoader/**/*.{swift,h,m,c,cc,mm,cpp}', 'ios/AirshipFrameworkProxy/**/*.{swift,h,m,c,cc,mm,cpp}'
 end
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/urbanairship/ios-library.git", from: "19.11.2")
+        .package(url: "https://github.com/urbanairship/ios-library.git", from: "19.11.6")
     ],
     targets: [
         .target(

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Airship
-airshipProxy = '14.10.1'
+airshipProxy = '14.10.2'
 airship = '19.13.6'
 
 # Gradle plugins


### PR DESCRIPTION
Retroactive release 14.10.2 for this issue: 
https://github.com/urbanairship/react-native-airship/issues/726

Need to make sure this is actually necessary just getting it ready