### PR TITLE
Fix IOSLiveActivitiesUpdated not firing after start() on iOS 17.2+

### DIFF
--- a/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
+++ b/ios/AirshipFrameworkProxy/LiveActivity/LiveActivityManager.swift
@@ -154,6 +154,12 @@ public actor LiveActivityManager: Sendable {
         let result = try await findEntry(attributesType: request.attributesType).start(request)
         if #unavailable(iOS 17.2) {
             await self.checkForActivities()
+        } else if activityState[result.id] == nil {
+            // On iOS 17.2+, checkForActivities() is not called on start (pushToStartTokenUpdates
+            // handles discovery at launch), so set up watching for the new activity directly.
+            await startWatchingActivityUpdates(result.id, attributesType: request.attributesType)
+            await updated(activityID: result.id, info: result, notifyOnChange: false)
+            await notify()
         }
         return result
     }


### PR DESCRIPTION
On iOS 17.2+, `start()` skipped `checkForActivities()` assuming `pushToStartTokenUpdates` would trigger watcher setup. That stream fires at launch and on system token refreshes, but not on direct app-initiated starts — so `startWatchingActivityUpdates` was never registered for the new activity and no `IOSLiveActivitiesUpdated` events were emitted.

Fix: after `start()` on iOS 17.2+, set up the watcher and emit the initial event inline, mirroring what `checkForActivities()` would have done. Guarded by `activityState[result.id] == nil` so it's a no-op if a concurrent `pushToStartTokenUpdates` already handled it.