### PR TITLE
Expose instance id, priority, and extras in pending embedded event

### DIFF
--- a/AirshipFrameworkProxy.podspec
+++ b/AirshipFrameworkProxy.podspec
@@ -1,6 +1,6 @@
 
 Pod::Spec.new do |s|
-   s.version                 = "15.11.0"
+   s.version                 = "15.12.0"
    s.name                    = "AirshipFrameworkProxy"
    s.summary                 = "Airship iOS mobile framework proxy"
    s.documentation_url       = "https://docs.airship.com/platform/mobile"

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PendingEmbeddedUpdated.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PendingEmbeddedUpdated.kt
@@ -10,6 +10,13 @@ internal class PendingEmbeddedUpdated(pending: List<AirshipEmbeddedInfo>) : Even
     override val type = EventType.PENDING_EMBEDDED_UPDATED
 
     override val body: JsonMap = jsonMapOf(
-        "pending" to pending.map { jsonMapOf( "embeddedId" to it.embeddedId ) }
+        "pending" to pending.map {
+            jsonMapOf(
+                "embeddedId" to it.embeddedId,
+                "instanceId" to it.instanceId,
+                "priority" to it.priority,
+                "extras" to it.extras
+            )
+        }
     )
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Airship
-airshipProxy = '15.11.0'
+airshipProxy = '15.12.0'
 airship = '20.9.0'
 
 # Gradle plugins

--- a/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
+++ b/ios/AirshipFrameworkProxy/AirshipProxyEvent.swift
@@ -215,7 +215,16 @@ struct EmbeddedInfoUpdatedEvent: AirshipProxyEvent {
     let body: Body
 
     init(pending: [AirshipEmbeddedInfo]) {
-        self.body = Body(pending: pending.map { Embedded(embeddedId: $0.embeddedID) })
+        self.body = Body(
+            pending: pending.map {
+                Embedded(
+                    embeddedId: $0.embeddedID,
+                    instanceId: $0.instanceID,
+                    priority: $0.priority,
+                    extras: $0.extras
+                )
+            }
+        )
     }
 
     struct Body: Codable, Sendable {
@@ -224,6 +233,9 @@ struct EmbeddedInfoUpdatedEvent: AirshipProxyEvent {
 
     struct Embedded: Codable, Sendable {
         let embeddedId: String
+        let instanceId: String
+        let priority: Int
+        let extras: AirshipJSON?
     }
 }
 


### PR DESCRIPTION
### What do these changes do?
Widens the `pending_embedded_updated` event body on both platforms to include `instanceId`, `priority`, and `extras` for each pending embedded content item, alongside the existing `embeddedId`. Bumps the proxy version to 15.12.0.

### Why are these changes necessary?
Framework wrappers (React Native, Flutter) need to discover the instance id and extras of pending embedded content so app code can target a specific instance. That data already exists in the native SDK's `AirshipEmbeddedInfo`, but the proxy's event body was dropping everything except `embeddedId`.

### How did you verify these changes?
Confirmed the widened event body builds cleanly on both platforms: `xcodebuild` against the `AirshipFrameworkProxy` iOS scheme and `./gradlew :airship-framework-proxy:compileDebugKotlin` on Android, both succeeded.