### PR TITLE
Fix spotless/ktlint version mismatch breaking Android formatting checks

### DIFF
--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipListener.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipListener.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.Airship
@@ -28,10 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
-internal class AirshipListener(
-    private val proxyStore: ProxyStore,
-    private val eventEmitter: EventEmitter
-) :
+internal class AirshipListener(private val proxyStore: ProxyStore, private val eventEmitter: EventEmitter) :
     MessageCenter.OnShowMessageCenterListener,
     PreferenceCenter.OnOpenListener,
     PushListener,
@@ -39,8 +38,7 @@ internal class AirshipListener(
     NotificationListener,
     DeepLinkListener,
     AirshipChannelListener,
-    InboxListener
-{
+    InboxListener {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val isAppForegrounded: Boolean
         get() {
@@ -52,23 +50,20 @@ internal class AirshipListener(
             return AirshipPluginExtensions.forwardNotificationListener
         }
 
-    override fun onShowMessageCenter(messageId: String?): Boolean {
-        return if (proxyStore.isAutoLaunchMessageCenterEnabled) {
-            false
-        } else {
-            eventEmitter.addEvent(DisplayMessageCenterEvent(messageId))
-            true
-        }
+    override fun onShowMessageCenter(messageId: String?): Boolean = if (proxyStore.isAutoLaunchMessageCenterEnabled) {
+        false
+    } else {
+        eventEmitter.addEvent(DisplayMessageCenterEvent(messageId))
+        true
     }
 
-    override fun onOpenPreferenceCenter(preferenceCenterId: String): Boolean {
-        return if (proxyStore.isAutoLaunchPreferenceCenterEnabled(preferenceCenterId)) {
+    override fun onOpenPreferenceCenter(preferenceCenterId: String): Boolean =
+        if (proxyStore.isAutoLaunchPreferenceCenterEnabled(preferenceCenterId)) {
             false
         } else {
             eventEmitter.addEvent(DisplayPreferenceCenterEvent(preferenceCenterId))
             true
         }
-    }
 
     override fun onPushReceived(message: PushMessage, notificationPosted: Boolean) {
         if (!notificationPosted) {
@@ -121,7 +116,7 @@ internal class AirshipListener(
 
     override fun onDeepLink(deepLink: String): Boolean {
         val override = AirshipPluginExtensions.onDeepLink?.invoke(deepLink)
-        when(override) {
+        when (override) {
             is AirshipPluginOverride.Override -> {
                 UALog.d { "Deeplink handling for $deepLink overridden by plugin extension" }
             }
@@ -146,7 +141,5 @@ internal class AirshipListener(
                 replacePending = true
             )
         }
-
     }
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipPluginExtender.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AirshipPluginExtender.kt
@@ -55,8 +55,5 @@ public interface AirshipPluginExtender {
     public fun extendConfig(
         context: Context,
         configBuilder: AirshipConfigOptions.Builder
-    ): AirshipConfigOptions.Builder {
-        return configBuilder
-    }
+    ): AirshipConfigOptions.Builder = configBuilder
 }
-

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AttributeOperation.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/AttributeOperation.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.channel.AttributeEditor
@@ -10,11 +12,15 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 public enum class AttributeOperationAction {
-    REMOVE, SET
+    REMOVE,
+    SET
 }
 
 public enum class AttributeValueType {
-    STRING, NUMBER, DATE, JSON
+    STRING,
+    NUMBER,
+    DATE,
+    JSON
 }
 
 public data class AttributeOperation(
@@ -62,11 +68,11 @@ internal fun AttributeOperation.applyOperation(editor: AttributeEditor) {
                     attribute,
                     requireNotNull(value).getDouble(0.0)
                 )
-                AttributeValueType.JSON ->  editor.setAttribute(
+                AttributeValueType.JSON -> editor.setAttribute(
                     attribute,
                     requireNotNull(instanceId),
                     expiry,
-                    requireNotNull(value).requireMap(),
+                    requireNotNull(value).requireMap()
                 )
             }
         }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/BaseAutopilot.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/BaseAutopilot.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 
@@ -7,18 +7,19 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import androidx.annotation.XmlRes
+import androidx.core.net.toUri
 import com.urbanairship.Airship
 import com.urbanairship.AirshipConfigOptions
 import com.urbanairship.Autopilot
-import com.urbanairship.UALog
 import com.urbanairship.Predicate
+import com.urbanairship.UALog
 import com.urbanairship.android.framework.proxy.Utils.getNamedResource
 import com.urbanairship.android.framework.proxy.events.EventEmitter
-import com.urbanairship.app.ApplicationListener
-import com.urbanairship.app.GlobalActivityMonitor
 import com.urbanairship.android.framework.proxy.events.NotificationStatusEvent
 import com.urbanairship.android.framework.proxy.events.PendingEmbeddedUpdated
 import com.urbanairship.android.framework.proxy.proxies.AirshipProxy
+import com.urbanairship.app.ApplicationListener
+import com.urbanairship.app.GlobalActivityMonitor
 import com.urbanairship.messagecenter.MessageCenter
 import com.urbanairship.permission.Permission
 import com.urbanairship.preferencecenter.PreferenceCenter
@@ -30,7 +31,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import androidx.core.net.toUri
 
 /**
  * Module's autopilot to customize Urban Airship.
@@ -108,8 +108,10 @@ public abstract class BaseAutopilot : Autopilot() {
         Airship.push.notificationProvider = notificationProvider
         Airship.push.foregroundNotificationDisplayPredicate = Predicate { message ->
             return@Predicate runBlocking {
-                val override = AirshipPluginExtensions.onShouldDisplayForegroundNotification?.invoke(message) ?: AirshipPluginOverride.UseDefault
-                return@runBlocking when(override) {
+                val override =
+                    AirshipPluginExtensions.onShouldDisplayForegroundNotification?.invoke(message)
+                        ?: AirshipPluginOverride.UseDefault
+                return@runBlocking when (override) {
                     is AirshipPluginOverride.Override -> {
                         override.result
                     }
@@ -139,6 +141,7 @@ public abstract class BaseAutopilot : Autopilot() {
     @SuppressLint("DiscouragedApi")
     private fun loadCustomNotificationChannels(context: Context) {
         val packageName = context.packageName
+
         @XmlRes val resId = context.resources.getIdentifier("ua_custom_notification_channels", "xml", packageName)
 
         if (resId != 0) {
@@ -150,6 +153,7 @@ public abstract class BaseAutopilot : Autopilot() {
     @SuppressLint("DiscouragedApi")
     private fun loadCustomNotificationButtonGroups(context: Context) {
         val packageName = context.packageName
+
         @XmlRes val resId = context.resources.getIdentifier("ua_custom_notification_buttons", "xml", packageName)
 
         if (resId != 0) {
@@ -185,8 +189,8 @@ public abstract class BaseAutopilot : Autopilot() {
         }
     }
 
-    public open fun createConfigBuilder(context: Context): AirshipConfigOptions.Builder {
-        return AirshipConfigOptions.newBuilder()
+    public open fun createConfigBuilder(context: Context): AirshipConfigOptions.Builder =
+        AirshipConfigOptions.newBuilder()
             .let {
                 try {
                     it.tryApplyDefaultProperties(context)
@@ -196,11 +200,8 @@ public abstract class BaseAutopilot : Autopilot() {
                 it
             }
             .setRequireInitialRemoteConfigEnabled(true)
-    }
 
-    override fun createAirshipConfigOptions(context: Context): AirshipConfigOptions? {
-        return configOptions
-    }
+    override fun createAirshipConfigOptions(context: Context): AirshipConfigOptions? = configOptions
 
     public abstract fun onMigrateData(context: Context, proxyStore: ProxyStore)
 }
@@ -238,7 +239,9 @@ public fun AirshipConfigOptions.Builder.applyProxyConfig(context: Context, proxy
     proxyConfig.isChannelCaptureEnabled?.let { this.setChannelCaptureEnabled(it) }
     proxyConfig.initialConfigUrl?.let { this.setInitialConfigUrl(it) }
     proxyConfig.urlAllowList?.let { this.setUrlAllowList(it.toTypedArray()) }
-    proxyConfig.urlAllowListScopeJavaScriptInterface?.let { this.setUrlAllowListScopeJavaScriptInterface(it.toTypedArray()) }
+    proxyConfig.urlAllowListScopeJavaScriptInterface?.let {
+        this.setUrlAllowListScopeJavaScriptInterface(it.toTypedArray())
+    }
     proxyConfig.urlAllowListScopeOpenUrl?.let { this.setUrlAllowListScopeOpenUrl(it.toTypedArray()) }
     proxyConfig.androidConfig?.appStoreUri?.let { this.setAppStoreUri(it.toUri()) }
     proxyConfig.androidConfig?.fcmFirebaseAppName?.let { this.setFcmFirebaseAppName(it) }
@@ -304,5 +307,3 @@ private class ExtenderProvider {
         const val EXTENDER_MANIFEST_KEY = "com.urbanairship.plugin.extender"
     }
 }
-
-

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/BaseNotificationProvider.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/BaseNotificationProvider.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 
@@ -15,9 +15,7 @@ public open class BaseNotificationProvider(
     internal val configOptions: AirshipConfigOptions
 ) : AirshipNotificationProvider(context, configOptions) {
 
-    internal fun applyNotificationConfig(
-        notificationConfig: NotificationConfig?
-    ) {
+    internal fun applyNotificationConfig(notificationConfig: NotificationConfig?) {
         this.defaultNotificationChannelId = resolveNotificationChannel(notificationConfig)
         this.smallIcon = resolveSmallIcon(notificationConfig)
         this.largeIcon = resolveLargeIcon(notificationConfig)
@@ -34,9 +32,8 @@ public open class BaseNotificationProvider(
     }
 
     internal companion object {
-        internal const val PUSH_MESSAGE_BUNDLE_EXTRA: String = "com.urbanairship.push_bundle";
+        internal const val PUSH_MESSAGE_BUNDLE_EXTRA: String = "com.urbanairship.push_bundle"
     }
-
 
     private fun resolveNotificationChannel(notificationConfig: NotificationConfig?): String {
         // NotificationConfig
@@ -88,7 +85,7 @@ public open class BaseNotificationProvider(
         }
 
         // AirshipConfig
-       return configOptions.notificationLargeIcon
+        return configOptions.notificationLargeIcon
     }
 
     private fun findDrawable(name: String?): Int? {
@@ -103,5 +100,4 @@ public open class BaseNotificationProvider(
             null
         }
     }
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/CustomMessageActivity.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/CustomMessageActivity.kt
@@ -109,7 +109,11 @@ public class CustomMessageActivity : FragmentActivity() {
 
             fragment.onMessageDeletedListener = MessageCenterMessageFragment.OnMessageDeletedListener {
                 fragment.deleteMessage(it)
-                val msg = resources.getQuantityString(com.urbanairship.messagecenter.core.R.plurals.ua_mc_description_deleted, 1, 1)
+                val msg = resources.getQuantityString(
+                    com.urbanairship.messagecenter.core.R.plurals.ua_mc_description_deleted,
+                    1,
+                    1
+                )
                 Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
                 finish()
             }
@@ -146,4 +150,3 @@ public class CustomMessageActivity : FragmentActivity() {
         }
     }
 }
-

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/EmailRegistrationProxyOptions.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/EmailRegistrationProxyOptions.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.contacts.EmailRegistrationOptions
@@ -11,8 +13,22 @@ public data class EmailRegistrationProxyOptions(
     public val doubleOptIn: Boolean
 ) {
     public constructor(json: JsonMap) : this(
-        transactionalOptedIn = if (json.opt("transactionalOptedIn").isNull) null else json.opt("transactionalOptedIn").getLong(0),
-        commercialOptedIn = if (json.opt("commercialOptedIn").isNull) null else json.opt("commercialOptedIn").getLong(0),
+        transactionalOptedIn = if (json.opt(
+                "transactionalOptedIn"
+            ).isNull
+        ) {
+            null
+        } else {
+            json.opt("transactionalOptedIn").getLong(0)
+        },
+        commercialOptedIn = if (json.opt(
+                "commercialOptedIn"
+            ).isNull
+        ) {
+            null
+        } else {
+            json.opt("commercialOptedIn").getLong(0)
+        },
         properties = json.opt("properties").map,
         doubleOptIn = json.opt("doubleOptIn").getBoolean(false)
     )

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/MessageCenterMessage.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/MessageCenterMessage.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.json.JsonMap

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/NotificationConfig.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/NotificationConfig.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.json.JsonMap
@@ -16,14 +18,13 @@ public data class NotificationConfig(
         icon = config["icon"]?.string,
         largeIcon = config["largeIcon"]?.string,
         accentColor = config["accentColor"]?.string,
-        defaultChannelId = config["defaultChannelId"]?.string,
+        defaultChannelId = config["defaultChannelId"]?.string
     )
 
-    override fun toJsonValue(): JsonValue =
-        jsonMapOf(
-            "icon" to icon,
-            "largeIcon" to largeIcon,
-            "accentColor" to accentColor,
-            "defaultChannelId" to defaultChannelId
-        ).toJsonValue()
+    override fun toJsonValue(): JsonValue = jsonMapOf(
+        "icon" to icon,
+        "largeIcon" to largeIcon,
+        "accentColor" to accentColor,
+        "defaultChannelId" to defaultChannelId
+    ).toJsonValue()
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/NotificationStatus.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/NotificationStatus.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.json.JsonSerializable
@@ -17,7 +19,7 @@ public data class NotificationStatus(
     public val notificationPermissionStatus: String?
 ) : JsonSerializable {
 
-    public constructor(value: JsonValue): this(
+    public constructor(value: JsonValue) : this(
         isUserNotificationsEnabled = value.requireMap().requireField("isUserNotificationsEnabled"),
         areNotificationsAllowed = value.requireMap().requireField("areNotificationsAllowed"),
         isPushPrivacyFeatureEnabled = value.requireMap().requireField("isPushPrivacyFeatureEnabled"),
@@ -38,12 +40,12 @@ public data class NotificationStatus(
     )
 
     override fun toJsonValue(): JsonValue = jsonMapOf(
-            "isUserNotificationsEnabled" to this.isUserNotificationsEnabled,
-            "areNotificationsAllowed" to this.areNotificationsAllowed,
-            "isPushPrivacyFeatureEnabled" to this.isPushPrivacyFeatureEnabled,
-            "isPushTokenRegistered" to this.isPushTokenRegistered,
-            "isUserOptedIn" to this.isUserOptedIn,
-            "isOptedIn" to this.isOptedIn,
-            "notificationPermissionStatus" to this.notificationPermissionStatus
+        "isUserNotificationsEnabled" to this.isUserNotificationsEnabled,
+        "areNotificationsAllowed" to this.areNotificationsAllowed,
+        "isPushPrivacyFeatureEnabled" to this.isPushPrivacyFeatureEnabled,
+        "isPushTokenRegistered" to this.isPushTokenRegistered,
+        "isUserOptedIn" to this.isUserOptedIn,
+        "isOptedIn" to this.isOptedIn,
+        "notificationPermissionStatus" to this.notificationPermissionStatus
     ).toJsonValue()
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/PendingEmbedded.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/PendingEmbedded.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.embedded.AirshipEmbeddedInfo
@@ -13,8 +15,8 @@ import kotlinx.coroutines.launch
 internal object PendingEmbedded {
     private val dispatcher = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
-    private  val _pending: MutableStateFlow<List<AirshipEmbeddedInfo>> = MutableStateFlow(emptyList())
-    val pending: StateFlow<List<AirshipEmbeddedInfo>> =  _pending.asStateFlow()
+    private val _pending: MutableStateFlow<List<AirshipEmbeddedInfo>> = MutableStateFlow(emptyList())
+    val pending: StateFlow<List<AirshipEmbeddedInfo>> = _pending.asStateFlow()
 
     init {
         dispatcher.launch {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyConfig.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyConfig.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.AirshipConfigOptions
@@ -32,7 +34,9 @@ public data class ProxyConfig(
         inProduction = config["inProduction"]?.boolean,
         initialConfigUrl = config["initialConfigUrl"]?.string,
         urlAllowList = config["urlAllowList"]?.list?.mapNotNull { it.string },
-        urlAllowListScopeJavaScriptInterface = config["urlAllowListScopeJavaScriptInterface"]?.list?.mapNotNull { it.string },
+        urlAllowListScopeJavaScriptInterface = config["urlAllowListScopeJavaScriptInterface"]?.list?.mapNotNull {
+            it.string
+        },
         urlAllowListScopeOpenUrl = config["urlAllowListScopeOpenUrl"]?.list?.mapNotNull { it.string },
         isChannelCaptureEnabled = config["isChannelCaptureEnabled"]?.boolean,
         isChannelCreationDelayEnabled = config["isChannelCreationDelayEnabled"]?.boolean,
@@ -41,28 +45,28 @@ public data class ProxyConfig(
         androidConfig = config["android"]?.map?.let { Android(it) }
     )
 
-    override fun toJsonValue(): JsonValue {
-        return JsonMap.newBuilder()
-            .put("default", defaultEnvironment)
-            .put("production", productionEnvironment)
-            .put("development", developmentEnvironment)
-            .put("site", site?.let { Utils.siteName(it) })
-            .putOpt("inProduction", inProduction)
-            .putOpt("initialConfigUrl", initialConfigUrl)
-            .putOpt("urlAllowList", urlAllowList)
-            .putOpt("urlAllowListScopeJavaScriptInterface", urlAllowListScopeJavaScriptInterface)
-            .putOpt("urlAllowListScopeOpenUrl", urlAllowListScopeOpenUrl)
-            .putOpt("isChannelCaptureEnabled", isChannelCaptureEnabled)
-            .putOpt("isChannelCreationDelayEnabled", isChannelCreationDelayEnabled)
-            .putOpt("enabledFeatures", enabledFeatures?.let { Utils.featureNames(it) })
-            .putOpt("autoPauseInAppAutomationOnLaunch", autoPauseInAppAutomationOnLaunch)
-            .putOpt("android", androidConfig)
-            .build()
-            .toJsonValue()
-    }
+    override fun toJsonValue(): JsonValue = JsonMap.newBuilder()
+        .put("default", defaultEnvironment)
+        .put("production", productionEnvironment)
+        .put("development", developmentEnvironment)
+        .put("site", site?.let { Utils.siteName(it) })
+        .putOpt("inProduction", inProduction)
+        .putOpt("initialConfigUrl", initialConfigUrl)
+        .putOpt("urlAllowList", urlAllowList)
+        .putOpt("urlAllowListScopeJavaScriptInterface", urlAllowListScopeJavaScriptInterface)
+        .putOpt("urlAllowListScopeOpenUrl", urlAllowListScopeOpenUrl)
+        .putOpt("isChannelCaptureEnabled", isChannelCaptureEnabled)
+        .putOpt("isChannelCreationDelayEnabled", isChannelCreationDelayEnabled)
+        .putOpt("enabledFeatures", enabledFeatures?.let { Utils.featureNames(it) })
+        .putOpt("autoPauseInAppAutomationOnLaunch", autoPauseInAppAutomationOnLaunch)
+        .putOpt("android", androidConfig)
+        .build()
+        .toJsonValue()
 
     public data class Environment(
-        val appKey: String?, val appSecret: String?, val logLevel: AirshipConfigOptions.LogLevel?
+        val appKey: String?,
+        val appSecret: String?,
+        val logLevel: AirshipConfigOptions.LogLevel?
     ) : JsonSerializable {
 
         override fun toJsonValue(): JsonValue = JsonMap.newBuilder()
@@ -72,9 +76,11 @@ public data class ProxyConfig(
             .build()
             .toJsonValue()
 
-        public constructor(config: JsonMap) : this(appKey = config["appKey"]?.string,
+        public constructor(config: JsonMap) : this(
+            appKey = config["appKey"]?.string,
             appSecret = config["appSecret"]?.string,
-            logLevel = config["logLevel"]?.string?.let { Utils.parseLogLevel(it) })
+            logLevel = config["logLevel"]?.string?.let { Utils.parseLogLevel(it) }
+        )
     }
 
     public data class Android(

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyLogger.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyLogger.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyStore.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ProxyStore.kt
@@ -1,11 +1,11 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.urbanairship.android.framework.proxy.proxies.PushProxy
 import com.urbanairship.UALog
+import com.urbanairship.android.framework.proxy.proxies.PushProxy
 import com.urbanairship.json.JsonSerializable
 import com.urbanairship.json.JsonValue
 import com.urbanairship.json.jsonMapOf
@@ -42,7 +42,7 @@ public class ProxyStore internal constructor(private val context: Context) {
 
     public var lastNotificationStatus: NotificationStatus?
         get() = getJson(NOTIFICATION_STATUS) {
-           NotificationStatus(it)
+            NotificationStatus(it)
         }
         set(status) = setJson(NOTIFICATION_STATUS, status)
 
@@ -78,13 +78,9 @@ public class ProxyStore internal constructor(private val context: Context) {
         }
     }
 
-    private fun getString(key: String, defaultValue: String?): String? {
-        return preferences.getString(key, defaultValue)
-    }
+    private fun getString(key: String, defaultValue: String?): String? = preferences.getString(key, defaultValue)
 
-    private fun getBoolean(key: String, defaultValue: Boolean): Boolean {
-        return preferences.getBoolean(key, defaultValue)
-    }
+    private fun getBoolean(key: String, defaultValue: Boolean): Boolean = preferences.getBoolean(key, defaultValue)
 
     private fun setString(key: String, value: String?) {
         if (value != null) {
@@ -110,9 +106,8 @@ public class ProxyStore internal constructor(private val context: Context) {
         }
     }
 
-    private fun getAutoLaunchPreferenceCenterKey(preferenceId: String): String {
-        return "${PREFERENCE_CENTER_AUTO_LAUNCH_PREFIX}_${preferenceId}"
-    }
+    private fun getAutoLaunchPreferenceCenterKey(preferenceId: String): String =
+        "${PREFERENCE_CENTER_AUTO_LAUNCH_PREFIX}_$preferenceId"
 
     internal companion object {
         private const val SHARED_PREFERENCES_FILE = "com.urbanairship.android.framework.proxy"

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ScopedSubscriptionListOperation.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/ScopedSubscriptionListOperation.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.contacts.Scope

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/SmsRegistrationProxyOptions.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/SmsRegistrationProxyOptions.kt
@@ -1,16 +1,14 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.contacts.SmsRegistrationOptions
 import com.urbanairship.json.JsonMap
 
-public data class SmsRegistrationProxyOptions(
-    public val senderId: String
-) {
+public data class SmsRegistrationProxyOptions(public val senderId: String) {
     public constructor(json: JsonMap) : this(
         senderId = json.require("senderId").requireString()
     )
 
-    public fun toSmsRegistrationOptions(): SmsRegistrationOptions {
-        return SmsRegistrationOptions.options(senderId)
-    }
+    public fun toSmsRegistrationOptions(): SmsRegistrationOptions = SmsRegistrationOptions.options(senderId)
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/SubscriptionOperation.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/SubscriptionOperation.kt
@@ -1,10 +1,13 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.channel.SubscriptionListEditor
 import com.urbanairship.json.JsonMap
 
 public enum class SubscriptionListOperationAction {
-    SUBSCRIBE, UNSUBSCRIBE
+    SUBSCRIBE,
+    UNSUBSCRIBE
 }
 
 public data class SubscriptionListOperation(

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/TagGroupOperation.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/TagGroupOperation.kt
@@ -1,10 +1,14 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.channel.TagGroupsEditor
 import com.urbanairship.json.JsonMap
 
 public enum class TagGroupOperationAction {
-    ADD, REMOVE, SET
+    ADD,
+    REMOVE,
+    SET
 }
 
 public data class TagGroupOperation(

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/TagOperation.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/TagOperation.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.channel.TagEditor
@@ -5,13 +7,11 @@ import com.urbanairship.channel.TagGroupsEditor
 import com.urbanairship.json.JsonMap
 
 public enum class TagOperationAction {
-    ADD, REMOVE
+    ADD,
+    REMOVE
 }
 
-public data class TagOperation(
-    public val tags: List<String>,
-    public val action: TagOperationAction
-) {
+public data class TagOperation(public val tags: List<String>, public val action: TagOperationAction) {
     public constructor(json: JsonMap) : this(
         tags = json.require("tags").requireList().map { it.requireString() },
         action = TagOperationAction.valueOf(

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/Utils.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/Utils.kt
@@ -6,59 +6,52 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import androidx.annotation.ColorInt
+import androidx.core.graphics.toColorInt
 import com.urbanairship.AirshipConfigOptions
 import com.urbanairship.PrivacyManager
 import com.urbanairship.UALog
 import com.urbanairship.json.JsonException
 import com.urbanairship.json.JsonValue
 import com.urbanairship.push.PushMessage
-import androidx.core.graphics.toColorInt
 
 /**
  * Module utils.
  */
 public object Utils {
 
-    public fun parseLogLevel(logLevel: String): AirshipConfigOptions.LogLevel {
-        return when (logLevel.lowercase().trim()) {
-            "verbose" -> AirshipConfigOptions.LogLevel.VERBOSE
-            "debug" -> AirshipConfigOptions.LogLevel.DEBUG
-            "info" -> AirshipConfigOptions.LogLevel.INFO
-            "warning" -> AirshipConfigOptions.LogLevel.WARN
-            "error" -> AirshipConfigOptions.LogLevel.ERROR
-            "none" -> AirshipConfigOptions.LogLevel.ASSERT
-            else -> {
-                throw JsonException("Invalid log level: $logLevel")
-            }
+    public fun parseLogLevel(logLevel: String): AirshipConfigOptions.LogLevel = when (logLevel.lowercase().trim()) {
+        "verbose" -> AirshipConfigOptions.LogLevel.VERBOSE
+        "debug" -> AirshipConfigOptions.LogLevel.DEBUG
+        "info" -> AirshipConfigOptions.LogLevel.INFO
+        "warning" -> AirshipConfigOptions.LogLevel.WARN
+        "error" -> AirshipConfigOptions.LogLevel.ERROR
+        "none" -> AirshipConfigOptions.LogLevel.ASSERT
+        else -> {
+            throw JsonException("Invalid log level: $logLevel")
         }
     }
 
-    public fun logLevelString(logLevel: AirshipConfigOptions.LogLevel): String {
-        return when (logLevel) {
-            AirshipConfigOptions.LogLevel.VERBOSE -> "verbose"
-            AirshipConfigOptions.LogLevel.DEBUG -> "debug"
-            AirshipConfigOptions.LogLevel.INFO -> "info"
-            AirshipConfigOptions.LogLevel.WARN -> "warning"
-            AirshipConfigOptions.LogLevel.ERROR -> "error"
-            AirshipConfigOptions.LogLevel.ASSERT -> "none"
-        }
+    public fun logLevelString(logLevel: AirshipConfigOptions.LogLevel): String = when (logLevel) {
+        AirshipConfigOptions.LogLevel.VERBOSE -> "verbose"
+        AirshipConfigOptions.LogLevel.DEBUG -> "debug"
+        AirshipConfigOptions.LogLevel.INFO -> "info"
+        AirshipConfigOptions.LogLevel.WARN -> "warning"
+        AirshipConfigOptions.LogLevel.ERROR -> "error"
+        AirshipConfigOptions.LogLevel.ASSERT -> "none"
     }
 
-    public fun parseLogPrivacyLevel(privacyLevel: String): AirshipConfigOptions.PrivacyLevel {
-        return when (privacyLevel.lowercase().trim()) {
+    public fun parseLogPrivacyLevel(privacyLevel: String): AirshipConfigOptions.PrivacyLevel =
+        when (privacyLevel.lowercase().trim()) {
             "public" -> AirshipConfigOptions.PrivacyLevel.PUBLIC
             "private" -> AirshipConfigOptions.PrivacyLevel.PRIVATE
             else -> {
                 throw JsonException("Invalid log privacy level: $privacyLevel")
             }
         }
-    }
 
-    public fun logPrivacyLevelString(privacyLevel: AirshipConfigOptions.PrivacyLevel): String {
-        return when (privacyLevel) {
-            AirshipConfigOptions.PrivacyLevel.PUBLIC -> "public"
-            AirshipConfigOptions.PrivacyLevel.PRIVATE -> "private"
-        }
+    public fun logPrivacyLevelString(privacyLevel: AirshipConfigOptions.PrivacyLevel): String = when (privacyLevel) {
+        AirshipConfigOptions.PrivacyLevel.PUBLIC -> "public"
+        AirshipConfigOptions.PrivacyLevel.PRIVATE -> "private"
     }
 
     public fun parseFeatures(value: JsonValue): PrivacyManager.Feature {
@@ -68,22 +61,17 @@ public object Utils {
         return PrivacyManager.Feature.NONE
     }
 
-    public fun parseSite(value: String): AirshipConfigOptions.Site {
-        return when (value.lowercase()) {
-            "eu" -> AirshipConfigOptions.Site.SITE_EU
-            "us" -> AirshipConfigOptions.Site.SITE_US
-            else -> {
-                throw IllegalArgumentException("Invalid site: $value")
-            }
+    public fun parseSite(value: String): AirshipConfigOptions.Site = when (value.lowercase()) {
+        "eu" -> AirshipConfigOptions.Site.SITE_EU
+        "us" -> AirshipConfigOptions.Site.SITE_US
+        else -> {
+            throw IllegalArgumentException("Invalid site: $value")
         }
     }
 
-
-    public fun siteName(value: AirshipConfigOptions.Site): String {
-        return when (value) {
-            AirshipConfigOptions.Site.SITE_EU -> "eu"
-            AirshipConfigOptions.Site.SITE_US -> "us"
-        }
+    public fun siteName(value: AirshipConfigOptions.Site): String = when (value) {
+        AirshipConfigOptions.Site.SITE_EU -> "eu"
+        AirshipConfigOptions.Site.SITE_US -> "us"
     }
 
     /**
@@ -96,11 +84,7 @@ public object Utils {
      */
     @SuppressLint("DiscouragedApi")
     @JvmStatic
-    public fun getNamedResource(
-        context: Context,
-        resourceName: String,
-        resourceFolder: String
-    ): Int {
+    public fun getNamedResource(context: Context, resourceName: String, resourceFolder: String): Int {
         if (resourceName.isNotBlank()) {
             val id =
                 context.resources.getIdentifier(resourceName, resourceFolder, context.packageName)
@@ -134,9 +118,8 @@ public object Utils {
     }
 
     @JvmStatic
-    public fun featureNames(features: PrivacyManager.Feature): List<String> {
-        return features.toJsonValue().optList().mapNotNull { it.string }
-    }
+    public fun featureNames(features: PrivacyManager.Feature): List<String> =
+        features.toJsonValue().optList().mapNotNull { it.string }
 
     private fun getNotificationId(notificationId: Int, notificationTag: String?): String {
         var id = notificationId.toString()
@@ -151,7 +134,6 @@ public object Utils {
         notificationId: Int? = null,
         notificationTag: String? = null
     ): Map<String, Any> {
-
         val notification = mutableMapOf<String, Any>()
         val extras = mutableMapOf<String, String>()
         for (key in message.getPushBundle().keySet()) {
@@ -172,7 +154,7 @@ public object Utils {
                 extras[key] = value
             }
         }
-        notification["extras"] = extras;
+        notification["extras"] = extras
 
         message.title?.let { notification["title"] = it }
         message.alert?.let { notification["alert"] = it }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/ChannelCreatedEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/ChannelCreatedEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DeepLinkEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DeepLinkEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 
@@ -13,5 +13,4 @@ internal class DeepLinkEvent(deepLink: String) : Event {
     override val type = EventType.DEEP_LINK_RECEIVED
 
     override val body: JsonMap = jsonMapOf("deepLink" to deepLink)
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DisplayMessageCenterEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DisplayMessageCenterEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DisplayPreferenceCenterEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/DisplayPreferenceCenterEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/Event.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/Event.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/EventEmitter.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/EventEmitter.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 
@@ -18,8 +18,8 @@ public class EventEmitter {
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     private val pendingEvents = mutableListOf<Event>()
-    private val _pendingEventsUpdates = MutableSharedFlow<Event>()
-    public val pendingEventListener: SharedFlow<Event> = _pendingEventsUpdates
+    private val pendingEventsFlow = MutableSharedFlow<Event>()
+    public val pendingEventListener: SharedFlow<Event> = pendingEventsFlow
 
     /**
      * Adds an event.
@@ -30,12 +30,14 @@ public class EventEmitter {
         synchronized(lock) {
             if (replacePending) {
                 val removed = pendingEvents.removeAll { event.type == it.type }
-                UALog.v { "addEvent replacePending=true, type=${event.type}, removed=$removed, pendingCount=${pendingEvents.size}" }
+                UALog.v {
+                    "addEvent replacePending=true, type=${event.type}, removed=$removed, pendingCount=${pendingEvents.size}"
+                }
             }
             pendingEvents.add(event)
             UALog.v { "addEvent emitted event: type=${event.type}, body=${event.body}, replacePending=$replacePending" }
             scope.launch {
-                _pendingEventsUpdates.emit(event)
+                pendingEventsFlow.emit(event)
             }
         }
     }
@@ -79,7 +81,9 @@ public class EventEmitter {
                     onProcess(it)
                 }
             }
-            UALog.v { "processPending types=$types, processed=$removed, pendingBefore=$before, pendingAfter=${pendingEvents.size}" }
+            UALog.v {
+                "processPending types=$types, processed=$removed, pendingBefore=$before, pendingAfter=${pendingEvents.size}"
+            }
         }
     }
 
@@ -92,8 +96,6 @@ public class EventEmitter {
          * @return The shared {@link EventEmitter} instance.
          */
         @JvmStatic
-        public fun shared(): EventEmitter {
-            return sharedInstance
-        }
+        public fun shared(): EventEmitter = sharedInstance
     }
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/MessageCenterUpdatedEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/MessageCenterUpdatedEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/NotificationResponseEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/NotificationResponseEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 
@@ -35,4 +35,3 @@ internal class NotificationResponseEvent(
         "actionId" to actionButtonInfo?.buttonId
     )
 }
-

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/NotificationStatusEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/NotificationStatusEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PendingEmbeddedUpdated.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PendingEmbeddedUpdated.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PushReceivedEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PushReceivedEvent.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.events
 
@@ -57,5 +57,4 @@ internal class PushReceivedEvent : Event {
         ),
         isForeground
     )
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PushTokenReceivedEvent.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/events/PushTokenReceivedEvent.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.events
 
 import com.urbanairship.json.JsonMap

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ActionProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ActionProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog
@@ -6,12 +8,9 @@ import com.urbanairship.actions.ActionRunner
 import com.urbanairship.actions.runSuspending
 import com.urbanairship.json.JsonValue
 
-public class ActionProxy internal constructor(
-    private val actionRunner: () -> ActionRunner
-) {
+public class ActionProxy internal constructor(private val actionRunner: () -> ActionRunner) {
     public suspend fun runAction(name: String, value: JsonValue?): ActionResult {
         UALog.v { "runAction called, name=$name, value=$value" }
         return actionRunner().runSuspending(name = name, value = value)
     }
 }
-

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/AirshipProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/AirshipProxy.kt
@@ -1,4 +1,4 @@
-/* Copyright Urban Airship and Contributors */
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy.proxies
 
@@ -6,11 +6,11 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.urbanairship.Airship
 import com.urbanairship.Autopilot
+import com.urbanairship.UALog
 import com.urbanairship.actions.DefaultActionRunner
 import com.urbanairship.android.framework.proxy.LaunchDeepLinkTracker
 import com.urbanairship.android.framework.proxy.ProxyConfig
 import com.urbanairship.android.framework.proxy.ProxyStore
-import com.urbanairship.UALog
 import com.urbanairship.automation.inAppAutomation
 import com.urbanairship.featureflag.FeatureFlagManager
 import com.urbanairship.json.JsonValue
@@ -18,10 +18,7 @@ import com.urbanairship.liveupdate.liveUpdateManager
 import com.urbanairship.messagecenter.messageCenter
 import com.urbanairship.preferencecenter.preferenceCenter
 
-public class AirshipProxy(
-    private val context: Context,
-    internal val proxyStore: ProxyStore
-) {
+public class AirshipProxy(private val context: Context, internal val proxyStore: ProxyStore) {
 
     public val actions: ActionProxy = ActionProxy {
         ensureTakeOff()
@@ -68,7 +65,7 @@ public class AirshipProxy(
         Airship.preferenceCenter
     }
 
-    public val privacyManager: PrivacyManagerProxy = PrivacyManagerProxy() {
+    public val privacyManager: PrivacyManagerProxy = PrivacyManagerProxy {
         ensureTakeOff()
         Airship.privacyManager
     }
@@ -86,14 +83,12 @@ public class AirshipProxy(
         }
     )
 
-    public val featureFlagManager: FeatureFlagManagerProxy = FeatureFlagManagerProxy() {
+    public val featureFlagManager: FeatureFlagManagerProxy = FeatureFlagManagerProxy {
         ensureTakeOff()
         FeatureFlagManager.shared()
     }
 
-    public fun takeOff(config: JsonValue): Boolean {
-        return takeOff(ProxyConfig(config.optMap()))
-    }
+    public fun takeOff(config: JsonValue): Boolean = takeOff(ProxyConfig(config.optMap()))
 
     public fun takeOff(config: ProxyConfig): Boolean {
         UALog.v { "TakeOff requested with config=$config" }
@@ -104,18 +99,14 @@ public class AirshipProxy(
         return flying
     }
 
-    public fun isFlying(): Boolean {
-        return Airship.isFlyingOrTakingOff
-    }
+    public fun isFlying(): Boolean = Airship.isFlyingOrTakingOff
 
     /**
      * Returns the deep link that launched the app from a notification tap,
      * or null if the app was not launched by a deep-link-carrying tap.
      * One-shot: the value is consumed on read.
      */
-    public suspend fun getLaunchDeepLink(): String? {
-        return LaunchDeepLinkTracker.shared().takeLaunchDeepLink()
-    }
+    public suspend fun getLaunchDeepLink(): String? = LaunchDeepLinkTracker.shared().takeLaunchDeepLink()
 
     public companion object {
         @SuppressLint("StaticFieldLeak")

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/AnalyticsProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/AnalyticsProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ChannelProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ChannelProxy.kt
@@ -1,7 +1,9 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.UALog
+import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.android.framework.proxy.SubscriptionListOperation
 import com.urbanairship.android.framework.proxy.TagGroupOperation
 import com.urbanairship.android.framework.proxy.TagOperation

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ContactProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/ContactProxy.kt
@@ -1,11 +1,13 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.UALog
-import com.urbanairship.android.framework.proxy.ScopedSubscriptionListOperation
-import com.urbanairship.android.framework.proxy.TagGroupOperation
+import com.urbanairship.android.framework.proxy.AttributeOperation
 import com.urbanairship.android.framework.proxy.EmailRegistrationProxyOptions
+import com.urbanairship.android.framework.proxy.ScopedSubscriptionListOperation
 import com.urbanairship.android.framework.proxy.SmsRegistrationProxyOptions
+import com.urbanairship.android.framework.proxy.TagGroupOperation
 import com.urbanairship.android.framework.proxy.applyOperation
 import com.urbanairship.contacts.Contact
 import com.urbanairship.json.JsonValue
@@ -112,5 +114,4 @@ public class ContactProxy internal constructor(private val contactProvider: () -
         }
         editor.apply()
     }
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/FeatureFlagManagerProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/FeatureFlagManagerProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog
@@ -16,7 +18,7 @@ public class FeatureFlagManagerProxy internal constructor(
 
     public val resultCache: ResultCacheProxy = ResultCacheProxy { featureFlagManagerProvider().resultCache }
 
-    public class ResultCacheProxy  internal constructor(private val cacheProvider: () -> FeatureFlagResultCache) {
+    public class ResultCacheProxy internal constructor(private val cacheProvider: () -> FeatureFlagResultCache) {
 
         public suspend fun cache(flag: FeatureFlagProxy, ttl: Duration) {
             UALog.v { "FeatureFlagManager.resultCache.cache called, flag=$flag, ttl=$ttl" }
@@ -46,11 +48,9 @@ public class FeatureFlagManagerProxy internal constructor(
     }
 }
 
-public data class FeatureFlagProxy(
-    internal val original: FeatureFlag,
-) : JsonSerializable {
+public data class FeatureFlagProxy(internal val original: FeatureFlag) : JsonSerializable {
 
-    public constructor(jsonValue: JsonValue): this(
+    public constructor(jsonValue: JsonValue) : this(
         FeatureFlag.fromJson(jsonValue.requireMap().requireField("_internal"))
     )
 

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/InAppProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/InAppProxy.kt
@@ -1,7 +1,9 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
-import com.urbanairship.android.framework.proxy.PendingEmbedded
 import com.urbanairship.UALog
+import com.urbanairship.android.framework.proxy.PendingEmbedded
 import com.urbanairship.android.framework.proxy.events.EventEmitter
 import com.urbanairship.android.framework.proxy.events.PendingEmbeddedUpdated
 import com.urbanairship.automation.InAppAutomation

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LiveUpdatesManagerProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LiveUpdatesManagerProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog
@@ -66,17 +68,16 @@ public class LiveUpdatesManagerProxy(private val managerProvider: () -> LiveUpda
     }
 }
 
-public class LiveUpdateProxy(private val liveUpdate: LiveUpdate): JsonSerializable {
-    override fun toJsonValue(): JsonValue {
-        return jsonMapOf(
-            "name" to liveUpdate.name,
-            "type" to liveUpdate.type,
-            "content" to liveUpdate.content,
-            "lastContentUpdateTimestamp" to liveUpdate.lastContentUpdateTime.let { DateUtils.createIso8601TimeStamp(it) },
-            "lastStateChangeTimestamp" to liveUpdate.lastStateChangeTime.let { DateUtils.createIso8601TimeStamp(it) },
-            "dismissTimestamp" to liveUpdate.dismissalTime?.let { DateUtils.createIso8601TimeStamp(it) }
-        ).toJsonValue()
-    }
+public class LiveUpdateProxy(private val liveUpdate: LiveUpdate) : JsonSerializable {
+    override fun toJsonValue(): JsonValue = jsonMapOf(
+        "name" to liveUpdate.name,
+        "type" to liveUpdate.type,
+        "content" to liveUpdate.content,
+        "lastContentUpdateTimestamp" to
+            liveUpdate.lastContentUpdateTime.let { DateUtils.createIso8601TimeStamp(it) },
+        "lastStateChangeTimestamp" to liveUpdate.lastStateChangeTime.let { DateUtils.createIso8601TimeStamp(it) },
+        "dismissTimestamp" to liveUpdate.dismissalTime?.let { DateUtils.createIso8601TimeStamp(it) }
+    ).toJsonValue()
 }
 
 public sealed class LiveUpdateRequest {
@@ -86,7 +87,7 @@ public sealed class LiveUpdateRequest {
         val content: JsonMap,
         val timestamp: Long? = null,
         val dismissalTimestamp: Long? = null
-    ): LiveUpdateRequest() {
+    ) : LiveUpdateRequest() {
         public companion object {
             @Throws(JsonException::class)
             public fun fromJson(jsonValue: JsonValue): Update {
@@ -94,7 +95,7 @@ public sealed class LiveUpdateRequest {
                 return Update(
                     name = map.requireField(NAME),
                     content = map.requireField(CONTENT),
-                    timestamp =  map.optionalField<String>(TIMESTAMP)?.let {
+                    timestamp = map.optionalField<String>(TIMESTAMP)?.let {
                         DateUtils.parseIso8601(it)
                     },
                     dismissalTimestamp = map.optionalField<String>(DISMISSAL_TIMESTAMP)?.let {
@@ -110,7 +111,7 @@ public sealed class LiveUpdateRequest {
         val content: JsonMap?,
         val timestamp: Long? = null,
         val dismissalTimestamp: Long? = null
-    ): LiveUpdateRequest() {
+    ) : LiveUpdateRequest() {
         public companion object {
             @Throws(JsonException::class)
             public fun fromJson(jsonValue: JsonValue): End {
@@ -118,7 +119,7 @@ public sealed class LiveUpdateRequest {
                 return End(
                     name = map.requireField(NAME),
                     content = map.optionalField(CONTENT),
-                    timestamp =  map.optionalField<String>(TIMESTAMP)?.let {
+                    timestamp = map.optionalField<String>(TIMESTAMP)?.let {
                         DateUtils.parseIso8601(it)
                     },
                     dismissalTimestamp = map.optionalField<String>(DISMISSAL_TIMESTAMP)?.let {
@@ -135,7 +136,7 @@ public sealed class LiveUpdateRequest {
         val content: JsonMap,
         val timestamp: Long? = null,
         val dismissalTimestamp: Long? = null
-    ): LiveUpdateRequest() {
+    ) : LiveUpdateRequest() {
         public companion object {
             @Throws(JsonException::class)
             public fun fromJson(jsonValue: JsonValue): Start {
@@ -144,7 +145,7 @@ public sealed class LiveUpdateRequest {
                     name = map.requireField(NAME),
                     type = map.requireField(TYPE),
                     content = map.requireField(CONTENT),
-                    timestamp =  map.optionalField<String>(TIMESTAMP)?.let {
+                    timestamp = map.optionalField<String>(TIMESTAMP)?.let {
                         DateUtils.parseIso8601(it)
                     },
                     dismissalTimestamp = map.optionalField<String>(DISMISSAL_TIMESTAMP)?.let {
@@ -155,9 +156,7 @@ public sealed class LiveUpdateRequest {
         }
     }
 
-    public data class List(
-        val type: String
-    ): LiveUpdateRequest() {
+    public data class List(val type: String) : LiveUpdateRequest() {
         public companion object {
             @Throws(JsonException::class)
             public fun fromJson(jsonValue: JsonValue): List {

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/LocaleProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/MessageCenterProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/MessageCenterProxy.kt
@@ -1,10 +1,12 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import android.content.Intent
 import android.net.Uri
 import com.urbanairship.Airship
-import com.urbanairship.android.framework.proxy.MessageCenterMessage
 import com.urbanairship.UALog
+import com.urbanairship.android.framework.proxy.MessageCenterMessage
 import com.urbanairship.android.framework.proxy.ProxyStore
 import com.urbanairship.messagecenter.MessageCenter
 import kotlinx.coroutines.MainScope
@@ -58,8 +60,10 @@ public class MessageCenterProxy internal constructor(
 
             try {
                 context.startActivity(intent)
-            } catch(exception: Exception) {
-                UALog.e(exception) { "Failed to launch Message Center, intentAction=$intentAction, messageId=$messageId" }
+            } catch (exception: Exception) {
+                UALog.e(exception) {
+                    "Failed to launch Message Center, intentAction=$intentAction, messageId=$messageId"
+                }
             }
         }
     }
@@ -88,7 +92,6 @@ public class MessageCenterProxy internal constructor(
         messageCenterProvider().inbox.deleteMessages(messageId)
     }
 
-
     public fun markMessageRead(messageId: String) {
         UALog.v { "markMessageRead called, messageId=$messageId" }
         messageCenterProvider().inbox.markMessagesRead(messageId)
@@ -108,5 +111,4 @@ public class MessageCenterProxy internal constructor(
         UALog.v { "setAutoLaunchDefaultMessageCenter called, enabled=$enabled" }
         proxyStore.isAutoLaunchMessageCenterEnabled = enabled
     }
-
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PreferenceCenterProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PreferenceCenterProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.UALog

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PrivacyManagerProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PrivacyManagerProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import com.urbanairship.PrivacyManager
@@ -5,9 +7,7 @@ import com.urbanairship.UALog
 import com.urbanairship.android.framework.proxy.Utils
 import com.urbanairship.json.JsonValue
 
-public class PrivacyManagerProxy internal constructor(
-    private val privacyManagerProvider: () -> PrivacyManager
-) {
+public class PrivacyManagerProxy internal constructor(private val privacyManagerProvider: () -> PrivacyManager) {
     public fun setEnabledFeatures(featureNames: List<String>) {
         UALog.v { "setEnabledFeatures called, featureNames=$featureNames" }
         setEnabledFeatures(
@@ -71,13 +71,10 @@ public class PrivacyManagerProxy internal constructor(
         )
     }
 
-    public fun isFeatureEnabled(featureNames: JsonValue): Boolean {
-        return isFeatureEnabled(
-            Utils.parseFeatures(featureNames)
-        )
-    }
+    public fun isFeatureEnabled(featureNames: JsonValue): Boolean = isFeatureEnabled(
+        Utils.parseFeatures(featureNames)
+    )
 
-    public fun isFeatureEnabled(features: PrivacyManager.Feature): Boolean {
-        return privacyManagerProvider().isEnabled(features)
-    }
+    public fun isFeatureEnabled(features: PrivacyManager.Feature): Boolean =
+        privacyManagerProvider().isEnabled(features)
 }

--- a/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PushProxy.kt
+++ b/android/airship-framework-proxy/src/main/java/com/urbanairship/android/framework/proxy/proxies/PushProxy.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy.proxies
 
 import android.app.NotificationManager
@@ -5,10 +7,10 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationManagerCompat
+import com.urbanairship.UALog
 import com.urbanairship.android.framework.proxy.BaseNotificationProvider
 import com.urbanairship.android.framework.proxy.NotificationConfig
 import com.urbanairship.android.framework.proxy.NotificationStatus
-import com.urbanairship.UALog
 import com.urbanairship.android.framework.proxy.ProxyStore
 import com.urbanairship.android.framework.proxy.Utils
 import com.urbanairship.json.JsonException
@@ -37,7 +39,9 @@ public class PushProxy internal constructor(
 
     public var isForegroundNotificationsEnabled: Boolean
         get() = store.isForegroundNotificationsEnabled
-        set(enabled) { store.isForegroundNotificationsEnabled = enabled }
+        set(enabled) {
+            store.isForegroundNotificationsEnabled = enabled
+        }
 
     public fun setNotificationConfig(config: JsonValue) {
         UALog.v { "setNotificationConfig called with $config" }
@@ -58,7 +62,9 @@ public class PushProxy internal constructor(
     public suspend fun enableUserPushNotifications(args: EnableUserNotificationsArgs? = null): Boolean {
         UALog.v { "enableUserPushNotifications called, args=$args" }
         return suspendCoroutine { continuation ->
-            pushProvider().enableUserNotifications(promptFallback = args?.fallback ?: PermissionPromptFallback.None) { result ->
+            pushProvider().enableUserNotifications(
+                promptFallback = args?.fallback ?: PermissionPromptFallback.None
+            ) { result ->
                 continuation.resumeWith(Result.success(result))
             }
         }
@@ -147,9 +153,7 @@ public class PushProxy internal constructor(
     }
 }
 
-public data class EnableUserNotificationsArgs(
-    val fallback: PermissionPromptFallback?,
-) : JsonSerializable {
+public data class EnableUserNotificationsArgs(val fallback: PermissionPromptFallback?) : JsonSerializable {
 
     public override fun toJsonValue(): JsonValue = jsonMapOf("fallback" to fallback).toJsonValue()
 

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/AttributeOperationTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/AttributeOperationTest.kt
@@ -1,3 +1,4 @@
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 
@@ -158,7 +159,7 @@ public class AttributeOperationTest {
     public fun testApplyJson() {
         val editor = mockk<AttributeEditor>(relaxed = true)
 
-        val operation  = AttributeOperation(
+        val operation = AttributeOperation(
             attribute = "some attribute",
             value = jsonMapOf("foo" to "bar").toJsonValue(),
             action = AttributeOperationAction.SET,
@@ -169,12 +170,14 @@ public class AttributeOperationTest {
 
         operation.applyOperation(editor)
 
-        verify { editor.setAttribute(
-            attribute = "some attribute",
-            instanceId = "instance id",
-            expiration = Date(1000),
-            json = jsonMapOf("foo" to "bar")
-        ) }
+        verify {
+            editor.setAttribute(
+                attribute = "some attribute",
+                instanceId = "instance id",
+                expiration = Date(1000),
+                json = jsonMapOf("foo" to "bar")
+            )
+        }
         confirmVerified(editor)
     }
 
@@ -182,7 +185,7 @@ public class AttributeOperationTest {
     public fun testApplyString() {
         val editor = mockk<AttributeEditor>(relaxed = true)
 
-        val operation  = AttributeOperation(
+        val operation = AttributeOperation(
             attribute = "some attribute",
             value = JsonValue.wrapOpt("neat"),
             action = AttributeOperationAction.SET,
@@ -199,7 +202,7 @@ public class AttributeOperationTest {
     public fun testApplyNumber() {
         val editor = mockk<AttributeEditor>(relaxed = true)
 
-        val operation  = AttributeOperation(
+        val operation = AttributeOperation(
             attribute = "some attribute",
             value = JsonValue.wrapOpt(100.1),
             action = AttributeOperationAction.SET,
@@ -216,7 +219,7 @@ public class AttributeOperationTest {
     public fun testApplyDate() {
         val editor = mockk<AttributeEditor>(relaxed = true)
 
-        val operation  = AttributeOperation(
+        val operation = AttributeOperation(
             attribute = "some attribute",
             value = JsonValue.wrapOpt(1682681877000),
             action = AttributeOperationAction.SET,
@@ -276,7 +279,6 @@ public class AttributeOperationTest {
         ).applyOperation(editor)
     }
 
-
     @Test(expected = java.lang.Exception::class)
     public fun testApplyNullString() {
         val editor = mockk<AttributeEditor>()
@@ -301,7 +303,6 @@ public class AttributeOperationTest {
         ).applyOperation(editor)
     }
 
-
     @Test(expected = java.lang.Exception::class)
     public fun testApplyNullNumber() {
         val editor = mockk<AttributeEditor>()
@@ -325,7 +326,6 @@ public class AttributeOperationTest {
             valueType = AttributeValueType.DATE
         ).applyOperation(editor)
     }
-
 
     @Test(expected = java.lang.Exception::class)
     public fun testApplyNullDate() {

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/EventEmitterTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/EventEmitterTest.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.android.framework.proxy.events.Event
@@ -54,5 +56,4 @@ public class EventEmitterTest {
     }
 }
 
-public class TestEvent(override val type: EventType, override val body: JsonMap = JsonMap.EMPTY_MAP):
-    Event
+public class TestEvent(override val type: EventType, override val body: JsonMap = JsonMap.EMPTY_MAP) : Event

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/FeatureTests.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/FeatureTests.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.PrivacyManager
@@ -21,7 +23,7 @@ public class FeatureTests {
                 "analytics",
                 "tags_and_attributes",
                 "feature_flags",
-                "contacts",
+                "contacts"
             ).sorted(),
             names.sorted()
         )
@@ -48,5 +50,4 @@ public class FeatureTests {
         val feature = Utils.parseFeatures(JsonValue.wrapOpt(emptyList<String>()))
         assertEquals(PrivacyManager.Feature.NONE, feature)
     }
-
 }

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/LaunchDeepLinkTrackerTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/LaunchDeepLinkTrackerTest.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import androidx.core.os.bundleOf

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/NotificationStatusTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/NotificationStatusTest.kt
@@ -1,3 +1,4 @@
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/ProxyConfigTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/ProxyConfigTest.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.json.JsonValue

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/ScopedSubscriptionListOperationTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/ScopedSubscriptionListOperationTest.kt
@@ -1,3 +1,4 @@
+/* Copyright Airship and Contributors */
 
 package com.urbanairship.android.framework.proxy
 

--- a/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/TagOperationTest.kt
+++ b/android/airship-framework-proxy/src/test/java/com/urbanairship/android/framework/proxy/TagOperationTest.kt
@@ -1,3 +1,5 @@
+/* Copyright Airship and Contributors */
+
 package com.urbanairship.android.framework.proxy
 
 import com.urbanairship.channel.TagEditor
@@ -107,5 +109,4 @@ public class TagOperationTest {
         verify { editor.removeTags(tags.toSet()) }
         confirmVerified(editor)
     }
-
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ spotless {
     kotlin {
         target '**/*.kt'
         targetExclude '.idea/**', 'build/**', '*/build/**'
-        ktlint(libs.versions.ktlint.get()).userData(["android": "true"])
+        ktlint(libs.versions.ktlint.get()).editorConfigOverride(["ktlint_code_style": "android_studio"])
 
         licenseHeaderFile "${rootDir}/gradle/spotless.license"
         trimTrailingWhitespace()

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ preferenceKtx = "1.2.1"
 spotlessPlugin = '8.1.0'
 
 # Spotless plugins
-ktlint = '0.45.2'
+ktlint = '1.7.1'
 
 # Dependencies
 


### PR DESCRIPTION
spotlessPlugin was bumped to 8.1.0 in #109 without bumping ktlint past 0.45.2, which Spotless no longer supports (dropped ktlint < 1.0 in 7.1.0). This has been crashing spotlessCheck/spotlessApply instead of running them since that PR merged.

Bumps ktlint to 1.7.1 (Spotless 8.1.0's own default) and updates the userData -> editorConfigOverride API call it requires. Running the check for the first time in years surfaced 3 real violations (2 mismatched filenames, 1 backing-property name) which are fixed here, plus applies the accumulated formatting drift (license header text, expression-body style, import order) across the rest of the Kotlin sources.